### PR TITLE
Use the `hypot` function in `Basic` conversions

### DIFF
--- a/src/crs/basic.jl
+++ b/src/crs/basic.jl
@@ -216,15 +216,14 @@ Spherical(args...) = Spherical{NoDatum}(args...)
 
 # Cartesian <> Polar
 Base.convert(::Type{Cartesian}, (; ρ, ϕ)::Polar) = Cartesian(ρ * cos(ϕ), ρ * sin(ϕ))
-Base.convert(::Type{Polar}, (; x, y)::Cartesian{<:Any,2}) = Polar(sqrt(x^2 + y^2), atanpos(y, x) * u"rad")
+Base.convert(::Type{Polar}, (; x, y)::Cartesian{<:Any,2}) = Polar(hypot(x, y), atanpos(y, x) * u"rad")
 
 # Cartesian <> Cylindrical
 Base.convert(::Type{Cartesian}, (; ρ, ϕ, z)::Cylindrical) = Cartesian(ρ * cos(ϕ), ρ * sin(ϕ), z)
-Base.convert(::Type{Cylindrical}, (; x, y, z)::Cartesian{<:Any,3}) =
-  Cylindrical(sqrt(x^2 + y^2), atanpos(y, x) * u"rad", z)
+Base.convert(::Type{Cylindrical}, (; x, y, z)::Cartesian{<:Any,3}) = Cylindrical(hypot(x, y), atanpos(y, x) * u"rad", z)
 
 # Cartesian <> Spherical
 Base.convert(::Type{Cartesian}, (; r, θ, ϕ)::Spherical) =
   Cartesian(r * sin(θ) * cos(ϕ), r * sin(θ) * sin(ϕ), r * cos(θ))
 Base.convert(::Type{Spherical}, (; x, y, z)::Cartesian{<:Any,3}) =
-  Spherical(sqrt(x^2 + y^2 + z^2), atan(sqrt(x^2 + y^2), z) * u"rad", atanpos(y, x) * u"rad")
+  Spherical(hypot(x, y, z), atan(hypot(x, y), z) * u"rad", atanpos(y, x) * u"rad")


### PR DESCRIPTION
The `hypot` function is more numerically stable than `sqrt(x₁^2 + x₂^2, ..., xₙ^2)` by avoiding overflow and underflow.