### PR TITLE
Add conversion fallbacks for Projected CRS

### DIFF
--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -73,7 +73,7 @@ function Base.convert(::Type{LatLon{Datum}}, coords::C) where {Datum,C<:Projecte
   LatLon{Datum}(rad2deg(ϕ) * u"°", rad2deg(λ) * u"°")
 end
 
-# projection conversion with same Datum
+# projection conversion with same datum
 function Base.convert(::Type{Cₜ}, coords::Cₛ) where {Datum,Cₜ<:Projected{Datum},Cₛ<:Projected{Datum}}
   latlon = convert(LatLon{Datum}, coords)
   convert(Cₜ, latlon)

--- a/src/crs/projected/eqareacylindrical.jl
+++ b/src/crs/projected/eqareacylindrical.jl
@@ -140,3 +140,13 @@ function Base.convert(::Type{LatLon{Datum}}, coords::EqualAreaCylindrical{latₜ
 
   LatLon{Datum}(rad2deg(ϕ) * u"°", rad2deg(λ) * u"°")
 end
+
+# ----------
+# FALLBACKS
+# ----------
+
+Base.convert(::Type{EqualAreaCylindrical{latₜₛ,lonₒ}}, coords::LatLon{Datum}) where {latₜₛ,lonₒ,Datum} =
+  convert(EqualAreaCylindrical{latₜₛ,lonₒ,Datum}, coords)
+
+Base.convert(::Type{LatLon}, coords::EqualAreaCylindrical{latₜₛ,lonₒ,Datum}) where {latₜₛ,lonₒ,Datum} =
+  convert(LatLon{Datum}, coords)

--- a/src/crs/projected/eqdistcylindrical.jl
+++ b/src/crs/projected/eqdistcylindrical.jl
@@ -69,3 +69,13 @@ function Base.convert(::Type{LatLon{Datum}}, coords::EquidistantCylindrical{lat�
 
   LatLon{Datum}(rad2deg(ϕ) * u"°", rad2deg(λ) * u"°")
 end
+
+# ----------
+# FALLBACKS
+# ----------
+
+Base.convert(::Type{EquidistantCylindrical{latₜₛ}}, coords::LatLon{Datum}) where {latₜₛ,Datum} =
+  convert(EquidistantCylindrical{latₜₛ,Datum}, coords)
+
+Base.convert(::Type{LatLon}, coords::EquidistantCylindrical{latₜₛ,Datum}) where {latₜₛ,Datum} =
+  convert(LatLon{Datum}, coords)

--- a/src/crs/projected/mercator.jl
+++ b/src/crs/projected/mercator.jl
@@ -78,3 +78,11 @@ function Base.convert(::Type{LatLon{Datum}}, coords::Mercator{Datum}) where {Dat
 
   LatLon{Datum}(rad2deg(ϕ) * u"°", rad2deg(λ) * u"°")
 end
+
+# ----------
+# FALLBACKS
+# ----------
+
+Base.convert(::Type{Mercator}, coords::LatLon{Datum}) where {Datum} = convert(Mercator{Datum}, coords)
+
+Base.convert(::Type{LatLon}, coords::Mercator{Datum}) where {Datum} = convert(LatLon{Datum}, coords)

--- a/src/crs/projected/orthographic.jl
+++ b/src/crs/projected/orthographic.jl
@@ -158,3 +158,13 @@ function Base.convert(::Type{LatLon{Datum}}, coords::C) where {latₒ,lonₒ,Dat
   λ, ϕ = projinv(fx, fy, x, y, λₛ, ϕₛ)
   LatLon{Datum}(rad2deg(ϕ) * u"°", rad2deg(λ) * u"°")
 end
+
+# ----------
+# FALLBACKS
+# ----------
+
+Base.convert(::Type{Orthographic{latₒ,lonₒ,S}}, coords::LatLon{Datum}) where {latₒ,lonₒ,S,Datum} =
+  convert(Orthographic{latₒ,lonₒ,S,Datum}, coords)
+
+Base.convert(::Type{LatLon}, coords::Orthographic{latₒ,lonₒ,S,Datum}) where {latₒ,lonₒ,S,Datum} =
+  convert(LatLon{Datum}, coords)

--- a/src/crs/projected/robinson.jl
+++ b/src/crs/projected/robinson.jl
@@ -156,3 +156,11 @@ function Base.convert(::Type{LatLon{Datum}}, coords::Robinson{Datum}) where {Dat
 
   LatLon{Datum}(rad2deg(ϕ) * u"°", rad2deg(λ) * u"°")
 end
+
+# ----------
+# FALLBACKS
+# ----------
+
+Base.convert(::Type{Robinson}, coords::LatLon{Datum}) where {Datum} = convert(Robinson{Datum}, coords)
+
+Base.convert(::Type{LatLon}, coords::Robinson{Datum}) where {Datum} = convert(LatLon{Datum}, coords)

--- a/src/crs/projected/transversemercator.jl
+++ b/src/crs/projected/transversemercator.jl
@@ -138,6 +138,16 @@ function Base.convert(::Type{LatLon{Datum}}, coords::TransverseMercator{k₀,lat
   LatLon{Datum}(rad2deg(ϕ) * u"°", rad2deg(λ) * u"°")
 end
 
+# ----------
+# FALLBACKS
+# ----------
+
+Base.convert(::Type{TransverseMercator{k₀,latₒ,lonₒ}}, coords::LatLon{Datum}) where {k₀,latₒ,lonₒ,Datum} =
+  convert(TransverseMercator{k₀,latₒ,lonₒ,Datum}, coords)
+
+Base.convert(::Type{LatLon}, coords::TransverseMercator{k₀,latₒ,lonₒ,Datum}) where {k₀,latₒ,lonₒ,Datum} =
+  convert(LatLon{Datum}, coords)
+
 # -----------------
 # HELPER FUNCTIONS
 # -----------------

--- a/src/crs/projected/utm.jl
+++ b/src/crs/projected/utm.jl
@@ -120,6 +120,16 @@ function Base.convert(::Type{LatLon{Datum}}, coords::C) where {Hemisphere,Zone,D
   convert(LatLon{Datum}, tm)
 end
 
+# ----------
+# FALLBACKS
+# ----------
+
+Base.convert(::Type{UTM{Hemisphere,Zone}}, coords::LatLon{Datum}) where {Hemisphere,Zone,Datum} =
+  convert(UTM{Hemisphere,Zone,Datum}, coords)
+
+Base.convert(::Type{LatLon}, coords::UTM{Hemisphere,Zone,Datum}) where {Hemisphere,Zone,Datum} =
+  convert(LatLon{Datum}, coords)
+
 # -----------------
 # HELPER FUNCTIONS
 # -----------------

--- a/src/crs/projected/webmercator.jl
+++ b/src/crs/projected/webmercator.jl
@@ -59,3 +59,11 @@ function Base.convert(::Type{LatLon{Datum}}, coords::WebMercator{Datum}) where {
   ϕ = atan(sinh(y / a))
   LatLon{Datum}(rad2deg(ϕ) * u"°", rad2deg(λ) * u"°")
 end
+
+# ----------
+# FALLBACKS
+# ----------
+
+Base.convert(::Type{WebMercator}, coords::LatLon{Datum}) where {Datum} = convert(WebMercator{Datum}, coords)
+
+Base.convert(::Type{LatLon}, coords::WebMercator{Datum}) where {Datum} = convert(LatLon{Datum}, coords)

--- a/src/crs/projected/winkeltripel.jl
+++ b/src/crs/projected/winkeltripel.jl
@@ -76,3 +76,11 @@ function Base.convert(::Type{LatLon{Datum}}, coords::C) where {lat₁,Datum,C<:W
   end
   LatLon{Datum}(rad2deg(ϕ) * u"°", rad2deg(λ) * u"°")
 end
+
+# ----------
+# FALLBACKS
+# ----------
+
+Base.convert(::Type{Winkel{lat₁}}, coords::LatLon{Datum}) where {lat₁,Datum} = convert(Winkel{lat₁,Datum}, coords)
+
+Base.convert(::Type{LatLon}, coords::Winkel{lat₁,Datum}) where {lat₁,Datum} = convert(LatLon{Datum}, coords)


### PR DESCRIPTION
```
julia> c1 = LatLon(30, 60)
GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 30.0°
└─ lon: 60.0°

julia> c2 = convert(Lambert, c1)
Lambert{WGS84Latest} coordinates
├─ x: 6.679169447596414e6 m
└─ y: 3.171259315518537e6 m

julia> c3 = convert(LatLon, c2)
GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 29.999999988166167°
└─ lon: 59.99999999999999°
```