### PR TITLE
Add Cartesian <> Projected fallback conversion

### DIFF
--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -89,3 +89,6 @@ end
 
 # avoid converting coordinates with the same type as the first argument
 Base.convert(::Type{C}, coords::C) where {Datum,C<:Projected{Datum}} = coords
+
+Base.convert(::Type{Cartesian}, coords::Projected) = convert(Cartesian, convert(LatLon, coords))
+Base.convert(P::Type{<:Projected}, coords::Cartesian) = convert(P, convert(LatLon, coords))

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -74,6 +74,9 @@ function Base.convert(::Type{LatLon{Datum}}, coords::C) where {Datum,C<:Projecte
   LatLon{Datum}(rad2deg(ϕ) * u"°", rad2deg(λ) * u"°")
 end
 
+Base.convert(C::Type{<:Cartesian}, coords::Projected) = convert(C, convert(LatLon, coords))
+Base.convert(C::Type{<:Projected}, coords::Cartesian) = convert(C, convert(LatLon, coords))
+
 # projection conversion with same datum
 function Base.convert(::Type{Cₜ}, coords::Cₛ) where {Datum,Cₜ<:Projected{Datum},Cₛ<:Projected{Datum}}
   latlon = convert(LatLon{Datum}, coords)
@@ -89,6 +92,3 @@ end
 
 # avoid converting coordinates with the same type as the first argument
 Base.convert(::Type{C}, coords::C) where {Datum,C<:Projected{Datum}} = coords
-
-Base.convert(C::Type{<:Cartesian}, coords::Projected) = convert(C, convert(LatLon, coords))
-Base.convert(C::Type{<:Projected}, coords::Cartesian) = convert(C, convert(LatLon, coords))

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -90,5 +90,5 @@ end
 # avoid converting coordinates with the same type as the first argument
 Base.convert(::Type{C}, coords::C) where {Datum,C<:Projected{Datum}} = coords
 
-Base.convert(::Type{Cartesian}, coords::Projected) = convert(Cartesian, convert(LatLon, coords))
-Base.convert(P::Type{<:Projected}, coords::Cartesian) = convert(P, convert(LatLon, coords))
+Base.convert(C::Type{<:Cartesian}, coords::Projected) = convert(C, convert(LatLon, coords))
+Base.convert(C::Type{<:Projected}, coords::Cartesian) = convert(C, convert(LatLon, coords))

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -506,20 +506,6 @@
       @inferred convert(LatLon, c2)
     end
 
-    @testset "Cartesian <> Mercator" begin
-      c1 = convert(Mercator, LatLon(T(30), T(40)))
-      c2 = convert(Cartesian, c1)
-      @test c2 ≈ Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
-      c3 = convert(Mercator, c2)
-      @test c3 ≈ c1
-
-      # type stability
-      c1 = Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
-      c2 = Mercator(T(0), T(0))
-      @inferred convert(Mercator, c1)
-      @inferred convert(Cartesian, c2)
-    end
-
     @testset "LatLon <> WebMercator" begin
       c1 = LatLon(T(45), T(90))
       c2 = convert(WebMercator, c1)
@@ -935,6 +921,31 @@
       c2 = ShiftedMercator(T(8349161.809495518), T(5591495.9185533915))
       @inferred convert(ShiftedMercator, c1)
       @inferred convert(LatLon, c2)
+    end
+
+    @testset "Cartesian <> Projected" begin
+      c1 = convert(Mercator, LatLon(T(30), T(40)))
+      c2 = convert(Cartesian, c1)
+      @test c2 ≈ Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
+      c3 = convert(Mercator, c2)
+
+      c1 = convert(OrthoNorth, LatLon(T(30), T(40)))
+      c2 = convert(Cartesian, c1)
+      @test c2 ≈ Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
+      c3 = convert(OrthoNorth, c2)
+      @test c3 ≈ c1
+      @test c3 ≈ c1
+
+      # type stability
+      c1 = Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
+      c2 = Mercator(T(0), T(0))
+      @inferred convert(Mercator, c1)
+      @inferred convert(Cartesian, c2)
+
+      c1 = Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
+      c2 = OrthoNorth(T(0), T(0))
+      @inferred convert(OrthoNorth, c1)
+      @inferred convert(Cartesian, c2)
     end
 
     @testset "Projection conversion" begin

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -938,14 +938,13 @@
 
       # type stability
       c1 = Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
-      c2 = Mercator(T(0), T(0))
+      c2 = Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
+      c3 = Mercator(T(0), T(0))
+      c4 = OrthoNorth(T(0), T(0))
       @inferred convert(Mercator, c1)
-      @inferred convert(Cartesian, c2)
-
-      c1 = Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
-      c2 = OrthoNorth(T(0), T(0))
-      @inferred convert(OrthoNorth, c1)
-      @inferred convert(Cartesian, c2)
+      @inferred convert(OrthoNorth, c2)
+      @inferred convert(Cartesian, c3)
+      @inferred convert(Cartesian, c4)
     end
 
     @testset "Projection conversion" begin

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -506,6 +506,20 @@
       @inferred convert(LatLon, c2)
     end
 
+    @testset "Cartesian <> Mercator" begin
+      c1 = convert(Mercator, LatLon(T(30), T(40)))
+      c2 = convert(Cartesian, c1)
+      @test c2 ≈ Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
+      c3 = convert(Mercator, c2)
+      @test c3 ≈ c1
+
+      # type stability
+      c1 = Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
+      c2 = Mercator(T(0), T(0))
+      @inferred convert(Mercator, c1)
+      @inferred convert(Cartesian, c2)
+    end
+
     @testset "LatLon <> WebMercator" begin
       c1 = LatLon(T(45), T(90))
       c2 = convert(WebMercator, c1)


### PR DESCRIPTION
Fixes the first half of #46. 

Note that while @juliohm suggested to use `LatLonAlt` as intermediate coordinate, this PR uses `LatLon` instead since `LatLonAlt <> Projected` conversion is not currently implemented. 