### PR TITLE
Remove the `CoordRefSystems` module from `Datum` shows

### DIFF
--- a/src/crs.jl
+++ b/src/crs.jl
@@ -81,13 +81,13 @@ ellipsoid(C::Type{<:CRS}) = ellipsoid(datum(C))
 function Base.summary(io::IO, coords::CRS)
   name = prettyname(coords)
   Datum = datum(coords)
-  print(io, "$name{$Datum} coordinates")
+  print(io, "$name{$(rmmodule(Datum))} coordinates")
 end
 
 function Base.show(io::IO, coords::CRS)
   name = prettyname(coords)
   Datum = datum(coords)
-  print(io, "$name{$Datum}(")
+  print(io, "$name{$(rmmodule(Datum))}(")
   printfields(io, coords, compact=true)
   print(io, ")")
 end

--- a/src/crs/basic.jl
+++ b/src/crs/basic.jl
@@ -82,12 +82,12 @@ end
 
 function Base.summary(io::IO, coords::Cartesian)
   Datum = datum(coords)
-  print(io, "Cartesian{$Datum} coordinates")
+  print(io, "Cartesian{$(rmmodule(Datum))} coordinates")
 end
 
 function Base.show(io::IO, coords::Cartesian)
   Datum = datum(coords)
-  print(io, "Cartesian{$Datum}(")
+  print(io, "Cartesian{$(rmmodule(Datum))}(")
   printfields(io, _coords(coords), _fnames(coords), compact=true)
   print(io, ")")
 end

--- a/src/crs/projected/shifted.jl
+++ b/src/crs/projected/shifted.jl
@@ -37,15 +37,15 @@ allapprox(coords₁::C, coords₂::C; kwargs...) where {C<:ShiftedCRS} =
 tol(coords::ShiftedCRS) = tol(_coords(coords))
 
 function Base.summary(io::IO, coords::ShiftedCRS{CRS,lonₒ,xₒ,yₒ}) where {CRS,lonₒ,xₒ,yₒ}
-  Datum = datum(coords)
   name = prettyname(CRS)
-  print(io, "Shifted$name{$Datum} coordinates with lonₒ: $lonₒ, xₒ: $xₒ, yₒ: $yₒ")
+  Datum = datum(coords)
+  print(io, "Shifted$name{$(rmmodule(Datum))} coordinates with lonₒ: $lonₒ, xₒ: $xₒ, yₒ: $yₒ")
 end
 
 function Base.show(io::IO, coords::ShiftedCRS{CRS}) where {CRS}
-  Datum = datum(coords)
   name = prettyname(CRS)
-  print(io, "Shifted$name{$Datum}(")
+  Datum = datum(coords)
+  print(io, "Shifted$name{$(rmmodule(Datum))}(")
   printfields(io, _coords(coords), compact=true)
   print(io, ")")
 end

--- a/src/ioutils.jl
+++ b/src/ioutils.jl
@@ -8,7 +8,14 @@ prettyname(obj) = prettyname(typeof(obj))
 function prettyname(T::Type)
   name = string(T)
   name = replace(name, r"{.*" => "")
-  replace(name, r".+\." => "")
+  replace(name, r".*\." => "")
+end
+
+# remove the "CoordRefSystems" module from type, 
+# it is displayed when the module is not imported
+function rmmodule(T)
+  name = string(T)
+  replace(name, "CoordRefSystems." => "")
 end
 
 printfields(io, obj; kwargs...) = printfields(io, obj, fieldnames(typeof(obj)); kwargs...)


### PR DESCRIPTION
When the the `CoordRefSystems` module are not imported, the string "CoordRefSystems." is displayed in front of the `Datum` type name.
This occurs in packages that use CoordRefSystems.jl internally, like [Meshes.jl](https://github.com/JuliaGeometry/Meshes.jl) for example.

 