### PR TITLE
Add rand methods to all CRS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,14 @@ authors = ["Elias Carvalho <eliascarvdev@gmail.com>", "Júlio Hoffimann <julio.h
 version = "0.6.0"
 
 [deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
+Random = "1.9"
 Rotations = "1.7"
 StaticArrays = "1.9"
 Unitful = "1.19"

--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -10,6 +10,8 @@ using Zygote: gradient
 using Rotations: RotXYZ
 using StaticArrays: SVector
 
+import Random
+
 include("utils.jl")
 include("ioutils.jl")
 include("ellipsoids.jl")

--- a/src/crs/basic.jl
+++ b/src/crs/basic.jl
@@ -43,6 +43,11 @@ Cartesian{Datum}(coords::Number...) where {Datum} = Cartesian{Datum}(addunit.(co
 
 Cartesian(args...) = Cartesian{NoDatum}(args...)
 
+# type aliases for internal use
+const Cartesian1 = Cartesian{NoDatum,1,Met{Float64}}
+const Cartesian2 = Cartesian{NoDatum,2,Met{Float64}}
+const Cartesian3 = Cartesian{NoDatum,3,Met{Float64}}
+
 Base.propertynames(::Cartesian) = (:x, :y, :z)
 
 function Base.getproperty(coords::Cartesian, name::Symbol)
@@ -85,6 +90,9 @@ function tol(coords::Cartesian)
 end
 
 lentype(::Type{Cartesian{Datum,N,L}}) where {Datum,N,L} = L
+
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{<:Cartesian{Datum,N}}) where {Datum,N} =
+  Cartesian{Datum}(ntuple(i -> rand(rng), N)...)
 
 function Base.summary(io::IO, coords::Cartesian)
   Datum = datum(coords)
@@ -157,6 +165,11 @@ ndims(::Type{<:Polar}) = 2
 
 lentype(::Type{<:Polar{Datum,L}}) where {Datum,L} = L
 
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Polar{Datum}}) where {Datum} =
+  Polar{Datum}(rand(rng), 2π * rand(rng))
+
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Polar}) = rand(rng, Polar{NoDatum})
+
 """
     Cylindrical(ρ, ϕ, z)
     Cylindrical{Datum}(ρ, ϕ, z)
@@ -203,6 +216,11 @@ ndims(::Type{<:Cylindrical}) = 3
 
 lentype(::Type{<:Cylindrical{Datum,L}}) where {Datum,L} = L
 
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Cylindrical{Datum}}) where {Datum} =
+  Cylindrical{Datum}(rand(rng), 2π * rand(rng), rand(rng))
+
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Cylindrical}) = rand(rng, Cylindrical{NoDatum})
+
 """
     Spherical(r, θ, ϕ)
     Spherical{Datum}(r, θ, ϕ)
@@ -244,6 +262,11 @@ Spherical(args...) = Spherical{NoDatum}(args...)
 ndims(::Type{<:Spherical}) = 3
 
 lentype(::Type{<:Spherical{Datum,L}}) where {Datum,L} = L
+
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Spherical{Datum}}) where {Datum} =
+  Spherical{Datum}(rand(rng), 2π * rand(rng), 2π * rand(rng))
+
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Spherical}) = rand(rng, Spherical{NoDatum})
 
 # ------------
 # CONVERSIONS

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -45,6 +45,11 @@ GeodeticLatLon(args...) = GeodeticLatLon{WGS84Latest}(args...)
 
 lentype(::Type{GeodeticLatLon{Datum,D}}) where {Datum,D} = Met{numtype(D)}
 
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeodeticLatLon{Datum}}) where {Datum} =
+  GeodeticLatLon{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng))
+
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeodeticLatLon}) = rand(rng, GeodeticLatLon{WGS84Latest})
+
 """
     LatLon(lat, lon)
     LatLon{Datum}(lat, lon)
@@ -104,6 +109,11 @@ GeodeticLatLonAlt(args...) = GeodeticLatLonAlt{WGS84Latest}(args...)
 
 lentype(::Type{GeodeticLatLonAlt{Datum,D,M}}) where {Datum,D,M} = M
 
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeodeticLatLonAlt{Datum}}) where {Datum} =
+  GeodeticLatLonAlt{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng), rand(rng))
+
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeodeticLatLonAlt}) = rand(rng, GeodeticLatLonAlt{WGS84Latest})
+
 """
     LatLonAlt(lat, lon, alt)
     LatLonAlt{Datum}(lat, lon, alt)
@@ -155,6 +165,11 @@ GeocentricLatLon(args...) = GeocentricLatLon{WGS84Latest}(args...)
 
 lentype(::Type{GeocentricLatLon{Datum,D}}) where {Datum,D} = Met{numtype(D)}
 
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeocentricLatLon{Datum}}) where {Datum} =
+  GeocentricLatLon{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng))
+
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeocentricLatLon}) = rand(rng, GeocentricLatLon{WGS84Latest})
+
 """
     AuthalicLatLon(lat, lon)
     AuthalicLatLon{Datum}(lat, lon)
@@ -186,6 +201,11 @@ AuthalicLatLon{Datum}(lat::Number, lon::Number) where {Datum} =
 AuthalicLatLon(args...) = AuthalicLatLon{WGS84Latest}(args...)
 
 lentype(::Type{AuthalicLatLon{Datum,D}}) where {Datum,D} = Met{numtype(D)}
+
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{AuthalicLatLon{Datum}}) where {Datum} =
+  AuthalicLatLon{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng))
+
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{AuthalicLatLon}) = rand(rng, AuthalicLatLon{WGS84Latest})
 
 # ------------
 # CONVERSIONS

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -33,6 +33,14 @@ Checks whether `latlon` coordinates are within the `CRS` domain.
 """
 indomain(C::Type{<:Projected}, (; lat, lon)::LatLon) = inbounds(C, ustrip(deg2rad(lon)), ustrip(deg2rad(lat)))
 
+function Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{C}) where {C<:Projected}
+  try
+    convert(C, rand(rng, LatLon))
+  catch
+    rand(rng, C)
+  end
+end
+
 # ----------------
 # IMPLEMENTATIONS
 # ----------------


### PR DESCRIPTION
This PR introduces `rand` methods for all CRS. It lacks tests, but we can add them later. The only problematic case I found is the random generation of projected CRS on custom ITRF datum:

```julia
rand(Mercator) # works
rand(Mercator{WGS84Latest}) # works
rand(Mercator{ITRF{2008}}) # fails
```

The last case enters into an infinite loop.