### PR TITLE
Update CRS show methods

### DIFF
--- a/src/crs.jl
+++ b/src/crs.jl
@@ -110,13 +110,13 @@ function Base.show(io::IO, coords::CRS)
   name = prettyname(coords)
   Datum = datum(coords)
   print(io, "$name{$(rmmodule(Datum))}(")
-  printfields(io, coords, compact=true)
+  printfields(io, cvalues(coords), cnames(coords), compact=true)
   print(io, ")")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", coords::CRS)
   summary(io, coords)
-  printfields(io, coords)
+  printfields(io, cvalues(coords), cnames(coords))
 end
 
 # ----------------

--- a/src/crs/basic.jl
+++ b/src/crs/basic.jl
@@ -89,26 +89,8 @@ lentype(::Type{Cartesian{Datum,N,L}}) where {Datum,N,L} = L
 Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Cartesian{Datum,N}}) where {Datum,N} =
   Cartesian{Datum}(ntuple(i -> rand(rng), N)...)
 
-function Base.summary(io::IO, coords::Cartesian)
-  Datum = datum(coords)
-  print(io, "Cartesian{$(rmmodule(Datum))} coordinates")
-end
-
-function Base.show(io::IO, coords::Cartesian)
-  Datum = datum(coords)
-  print(io, "Cartesian{$(rmmodule(Datum))}(")
-  printfields(io, _coords(coords), _fnames(coords), compact=true)
-  print(io, ")")
-end
-
-function Base.show(io::IO, ::MIME"text/plain", coords::Cartesian)
-  summary(io, coords)
-  printfields(io, _coords(coords), _fnames(coords))
-end
-
 _coords(coords::Cartesian) = getfield(coords, :coords)
 
-_fnames(coords::Cartesian) = _fnames(typeof(coords))
 function _fnames(::Type{<:Cartesian{Datum,N}}) where {Datum,N}
   if N == 1
     (:x,)

--- a/src/crs/projected/shifted.jl
+++ b/src/crs/projected/shifted.jl
@@ -42,23 +42,12 @@ tol(coords::ShiftedCRS) = tol(_coords(coords))
 
 lentype(::Type{<:ShiftedCRS{CRS}}) where {CRS} = lentype(CRS)
 
+prettyname(::Type{<:ShiftedCRS{CRS}}) where {CRS} = "Shifted$(prettyname(CRS))"
+
 function Base.summary(io::IO, coords::ShiftedCRS{CRS,lonₒ,xₒ,yₒ}) where {CRS,lonₒ,xₒ,yₒ}
-  name = prettyname(CRS)
+  name = prettyname(coords)
   Datum = datum(coords)
-  print(io, "Shifted$name{$(rmmodule(Datum))} coordinates with lonₒ: $lonₒ, xₒ: $xₒ, yₒ: $yₒ")
-end
-
-function Base.show(io::IO, coords::ShiftedCRS{CRS}) where {CRS}
-  name = prettyname(CRS)
-  Datum = datum(coords)
-  print(io, "Shifted$name{$(rmmodule(Datum))}(")
-  printfields(io, _coords(coords), compact=true)
-  print(io, ")")
-end
-
-function Base.show(io::IO, ::MIME"text/plain", coords::ShiftedCRS)
-  summary(io, coords)
-  printfields(io, _coords(coords))
+  print(io, "$name{$(rmmodule(Datum))} coordinates with lonₒ: $lonₒ, xₒ: $xₒ, yₒ: $yₒ")
 end
 
 # ------------


### PR DESCRIPTION
Using the new `cnames` and `cvalues` functions, show methods can only be defined for `CRS` type.