### PR TITLE
Update `Cartesian` constructors

### DIFF
--- a/src/crs/basic.jl
+++ b/src/crs/basic.jl
@@ -12,6 +12,8 @@ abstract type Basic{Datum} <: CRS{Datum} end
 """
     Cartesian(x₁, x₂, ..., xₙ)
     Cartesian{Datum}(x₁, x₂, ..., xₙ)
+    Cartesian((x₁, x₂, ..., xₙ))
+    Cartesian{Datum}((x₁, x₂, ..., xₙ))
 
 N-dimensional Cartesian coordinates `x₁, x₂, ..., xₙ` in length units (default to meter)
 with a given `Datum` (default to `NoDatum`).
@@ -24,6 +26,12 @@ Cartesian(1, 1) # add default units
 Cartesian(1u"m", 1u"m") # integers are converted converted to floats
 Cartesian(1.0u"km", 1.0u"km", 1.0u"km")
 Cartesian{WGS84Latest}(1.0u"m", 1.0u"m")
+
+# constructing with tuples
+Cartesian((1, 1))
+Cartesian((1u"m", 1u"m"))
+Cartesian((1.0u"km", 1.0u"km", 1.0u"km"))
+Cartesian{WGS84Latest}((1.0u"m", 1.0u"m"))
 ```
 
 ## References
@@ -37,9 +45,9 @@ struct Cartesian{Datum,N,L<:Len} <: Basic{Datum}
 end
 
 Cartesian{Datum}(coords::NTuple{N,L}) where {Datum,N,L<:Len} = Cartesian{Datum,N,float(L)}(coords)
-Cartesian{Datum}(coords::L...) where {Datum,L<:Len} = Cartesian{Datum}(coords)
-Cartesian{Datum}(coords::Len...) where {Datum} = Cartesian{Datum}(promote(coords...))
-Cartesian{Datum}(coords::Number...) where {Datum} = Cartesian{Datum}(addunit.(coords, u"m")...)
+Cartesian{Datum}(coords::NTuple{N,Len}) where {Datum,N} = Cartesian{Datum}(promote(coords...))
+Cartesian{Datum}(coords::NTuple{N,Number}) where {Datum,N} = Cartesian{Datum}(addunit.(coords, u"m"))
+Cartesian{Datum}(coords::Number...) where {Datum} = Cartesian{Datum}(coords)
 
 Cartesian(args...) = Cartesian{NoDatum}(args...)
 

--- a/src/crs/basic.jl
+++ b/src/crs/basic.jl
@@ -26,12 +26,6 @@ Cartesian(1, 1) # add default units
 Cartesian(1u"m", 1u"m") # integers are converted converted to floats
 Cartesian(1.0u"km", 1.0u"km", 1.0u"km")
 Cartesian{WGS84Latest}(1.0u"m", 1.0u"m")
-
-# constructing with tuples
-Cartesian((1, 1))
-Cartesian((1u"m", 1u"m"))
-Cartesian((1.0u"km", 1.0u"km", 1.0u"km"))
-Cartesian{WGS84Latest}((1.0u"m", 1.0u"m"))
 ```
 
 ## References

--- a/test/crs/constructors.jl
+++ b/test/crs/constructors.jl
@@ -5,6 +5,9 @@
       @test Cartesian(T(1), T(1)) == Cartesian(T(1) * u"m", T(1) * u"m")
       @test Cartesian(T(1), T(1), T(1)) == Cartesian(T(1) * u"m", T(1) * u"m", T(1) * u"m")
       @test Cartesian(T(1) * u"m", 1 * u"m") == Cartesian(T(1) * u"m", T(1) * u"m")
+      @test Cartesian((T(1), T(1))) == Cartesian((T(1) * u"m", T(1) * u"m"))
+      @test Cartesian((T(1), T(1), T(1))) == Cartesian((T(1) * u"m", T(1) * u"m", T(1) * u"m"))
+      @test Cartesian((T(1) * u"m", 1 * u"m")) == Cartesian((T(1) * u"m", T(1) * u"m"))
 
       c = Cartesian(T(1))
       @test sprint(show, c) == "Cartesian{NoDatum}(x: 1.0 m)"


### PR DESCRIPTION
Now, `Cartesian` constructors accept a tuple of number or a tuple of quantities:
```julia
Cartesian((1.0, 1.0))
Cartesian((1.0u"m", 1.0u"m"))
```
closes #71