### PR TITLE
Add GRS 1980 Authalic Sphere ellipsoid and datum

### DIFF
--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -47,6 +47,7 @@ export
   Ire65,
   NZGD1949,
   OSGB36,
+  GRS80S,
   ellipsoid,
   epoch,
 

--- a/src/datums.jl
+++ b/src/datums.jl
@@ -176,3 +176,12 @@ Airy 1830 datum.
 abstract type OSGB36 <: Datum end
 
 ellipsoid(::Type{OSGB36}) = Airy🌎
+
+"""
+    GRS80S
+
+GRS 1980 Authalic Sphere datum.
+"""
+abstract type GRS80S <: Datum end
+
+ellipsoid(::Type{GRS80S}) = GRS80S🌎

--- a/src/ellipsoids.jl
+++ b/src/ellipsoids.jl
@@ -136,6 +136,17 @@ const _GRS80 = ellipfromaf⁻¹(6378137.0u"m", 298.257222101)
 ellipsoidparams(::Type{GRS80🌎}) = _GRS80
 
 """
+  GRS80S🌎
+
+GRS 1980 (IUGG, 1980) Authalic Sphere.
+"""
+abstract type GRS80S🌎 <: RevolutionEllipsoid end
+
+const _GRS80S = ellipfromab(6371007.0u"m", 6371007.0u"m")
+
+ellipsoidparams(::Type{GRS80S🌎}) = _GRS80S
+
+"""
   MERIT🌎
 
 MERIT 1983 ellipsoid.

--- a/test/datums.jl
+++ b/test/datums.jl
@@ -56,6 +56,10 @@
     @test ellipsoid(OSGB36) === CoordRefSystems.Airy🌎
   end
 
+@testset "GRS80S" begin
+    @test ellipsoid(GRS80S) === CoordRefSystems.GRS80S🌎
+  end
+
   @testset "ShiftedDatum" begin
     ShiftedWGS84 = CoordRefSystems.shift(WGS84Latest, 2024.0)
     @test ellipsoid(ShiftedWGS84) === CoordRefSystems.WGS84🌎

--- a/test/ellipsoids.jl
+++ b/test/ellipsoids.jl
@@ -229,6 +229,16 @@
     @test flattening⁻¹(🌎) == 298.257222101
   end
 
+  @testset "GRS80S🌎" begin
+    🌎 = CoordRefSystems.GRS80S🌎
+    @test majoraxis(🌎) == 6.371007e6u"m"
+    @test minoraxis(🌎) == 6.371007e6u"m"
+    @test eccentricity(🌎) == 0.0
+    @test eccentricity²(🌎) == 0.0
+    @test flattening(🌎) == 0.0
+    @test flattening⁻¹(🌎) == Inf
+  end
+
   @testset "GSK2011🌎" begin
     🌎 = CoordRefSystems.GSK2011🌎
     @test majoraxis(🌎) == 6.3781365e6u"m"


### PR DESCRIPTION
As discussed in #98, this PR adds the GRS 1980 Authalic sphere, I tried following the same style for code and tests, I also added his new datum among the exports as they all seem to be there.

In the end I did not add the NSIDC datum as I only that in case the GRS80S could not be added due to a lack of corresponding datum.
Given that I could add the GRS80 I'd avoid adding the very other niche datum/ellipsoid.