### PR TITLE
Add back latitude check and improve `fixlon` 

### DIFF
--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -33,9 +33,12 @@ See [EPSG:4326](https://epsg.io/4326).
 struct GeodeticLatLon{Datum,D<:Deg} <: Geographic{Datum}
   lat::D
   lon::D
+  function GeodeticLatLon{Datum, D}(lat, lon) where {Datum,D<:Deg} 
+    new{Datum,D}(checklat(lat), fixlon(lon))
+  end
 end
 
-GeodeticLatLon{Datum}(lat::D, lon::D) where {Datum,D<:Deg} = GeodeticLatLon{Datum,float(D)}(lat, fixlon(lon))
+GeodeticLatLon{Datum}(lat::D, lon::D) where {Datum,D<:Deg} = GeodeticLatLon{Datum,float(D)}(lat, lon)
 GeodeticLatLon{Datum}(lat::Deg, lon::Deg) where {Datum} = GeodeticLatLon{Datum}(promote(lat, lon)...)
 GeodeticLatLon{Datum}(lat::Rad, lon::Rad) where {Datum} = GeodeticLatLon{Datum}(rad2deg(lat), rad2deg(lon))
 GeodeticLatLon{Datum}(lat::Number, lon::Number) where {Datum} = GeodeticLatLon{Datum}(addunit(lat, °), addunit(lon, °))
@@ -106,10 +109,13 @@ struct GeodeticLatLonAlt{Datum,D<:Deg,M<:Met} <: Geographic{Datum}
   lat::D
   lon::D
   alt::M
+  function GeodeticLatLonAlt{Datum,D,M}(lat, lon, alt) where {Datum,D<:Deg,M<:Met}
+    new(checklat(lat), fixlon(lon), alt)
+  end
 end
 
 GeodeticLatLonAlt{Datum}(lat::D, lon::D, alt::M) where {Datum,D<:Deg,M<:Met} =
-  GeodeticLatLonAlt{Datum,float(D),float(M)}(lat, fixlon(lon), alt)
+  GeodeticLatLonAlt{Datum,float(D),float(M)}(lat, lon, alt)
 GeodeticLatLonAlt{Datum}(lat::Deg, lon::Deg, alt::Met) where {Datum} =
   GeodeticLatLonAlt{Datum}(promote(lat, lon)..., alt)
 GeodeticLatLonAlt{Datum}(lat::Deg, lon::Deg, alt::Len) where {Datum} =
@@ -185,9 +191,12 @@ GeocentricLatLon{WGS84Latest}(45.0°, 45.0°)
 struct GeocentricLatLon{Datum,D<:Deg} <: Geographic{Datum}
   lat::D
   lon::D
+  function GeocentricLatLon{Datum, D}(lat, lon) where {Datum,D<:Deg}
+    new(checklat(lat), fixlon(lon))
+  end
 end
 
-GeocentricLatLon{Datum}(lat::D, lon::D) where {Datum,D<:Deg} = GeocentricLatLon{Datum,float(D)}(lat, fixlon(lon))
+GeocentricLatLon{Datum}(lat::D, lon::D) where {Datum,D<:Deg} = GeocentricLatLon{Datum,float(D)}(lat, lon)
 GeocentricLatLon{Datum}(lat::Deg, lon::Deg) where {Datum} = GeocentricLatLon{Datum}(promote(lat, lon)...)
 GeocentricLatLon{Datum}(lat::Rad, lon::Rad) where {Datum} = GeocentricLatLon{Datum}(rad2deg(lat), rad2deg(lon))
 GeocentricLatLon{Datum}(lat::Number, lon::Number) where {Datum} =
@@ -237,6 +246,9 @@ AuthalicLatLon{WGS84Latest}(45.0°, 45.0°)
 struct AuthalicLatLon{Datum,D<:Deg} <: Geographic{Datum}
   lat::D
   lon::D
+  function AuthalicLatLon{Datum,D}(lat, lon) where {Datum,D<:Deg} 
+    new(checklat(lat), fixlon(lon))
+  end
 end
 
 AuthalicLatLon{Datum}(lat::D, lon::D) where {Datum,D<:Deg} = AuthalicLatLon{Datum,float(D)}(lat, fixlon(lon))

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -33,12 +33,9 @@ See [EPSG:4326](https://epsg.io/4326).
 struct GeodeticLatLon{Datum,D<:Deg} <: Geographic{Datum}
   lat::D
   lon::D
-  function GeodeticLatLon{Datum, D}(lat, lon) where {Datum,D<:Deg} 
-    new{Datum,D}(checklat(lat), fixlon(lon))
-  end
 end
 
-GeodeticLatLon{Datum}(lat::D, lon::D) where {Datum,D<:Deg} = GeodeticLatLon{Datum,float(D)}(lat, lon)
+GeodeticLatLon{Datum}(lat::D, lon::D) where {Datum,D<:Deg} = GeodeticLatLon{Datum,float(D)}(checklat(lat), fixlon(lon))
 GeodeticLatLon{Datum}(lat::Deg, lon::Deg) where {Datum} = GeodeticLatLon{Datum}(promote(lat, lon)...)
 GeodeticLatLon{Datum}(lat::Rad, lon::Rad) where {Datum} = GeodeticLatLon{Datum}(rad2deg(lat), rad2deg(lon))
 GeodeticLatLon{Datum}(lat::Number, lon::Number) where {Datum} = GeodeticLatLon{Datum}(addunit(lat, °), addunit(lon, °))
@@ -109,13 +106,10 @@ struct GeodeticLatLonAlt{Datum,D<:Deg,M<:Met} <: Geographic{Datum}
   lat::D
   lon::D
   alt::M
-  function GeodeticLatLonAlt{Datum,D,M}(lat, lon, alt) where {Datum,D<:Deg,M<:Met}
-    new(checklat(lat), fixlon(lon), alt)
-  end
 end
 
 GeodeticLatLonAlt{Datum}(lat::D, lon::D, alt::M) where {Datum,D<:Deg,M<:Met} =
-  GeodeticLatLonAlt{Datum,float(D),float(M)}(lat, lon, alt)
+  GeodeticLatLonAlt{Datum,float(D),float(M)}(checklat(lat), fixlon(lon), alt)
 GeodeticLatLonAlt{Datum}(lat::Deg, lon::Deg, alt::Met) where {Datum} =
   GeodeticLatLonAlt{Datum}(promote(lat, lon)..., alt)
 GeodeticLatLonAlt{Datum}(lat::Deg, lon::Deg, alt::Len) where {Datum} =
@@ -191,12 +185,9 @@ GeocentricLatLon{WGS84Latest}(45.0°, 45.0°)
 struct GeocentricLatLon{Datum,D<:Deg} <: Geographic{Datum}
   lat::D
   lon::D
-  function GeocentricLatLon{Datum, D}(lat, lon) where {Datum,D<:Deg}
-    new(checklat(lat), fixlon(lon))
-  end
 end
 
-GeocentricLatLon{Datum}(lat::D, lon::D) where {Datum,D<:Deg} = GeocentricLatLon{Datum,float(D)}(lat, lon)
+GeocentricLatLon{Datum}(lat::D, lon::D) where {Datum,D<:Deg} = GeocentricLatLon{Datum,float(D)}(checklat(lat), fixlon(lon))
 GeocentricLatLon{Datum}(lat::Deg, lon::Deg) where {Datum} = GeocentricLatLon{Datum}(promote(lat, lon)...)
 GeocentricLatLon{Datum}(lat::Rad, lon::Rad) where {Datum} = GeocentricLatLon{Datum}(rad2deg(lat), rad2deg(lon))
 GeocentricLatLon{Datum}(lat::Number, lon::Number) where {Datum} =
@@ -246,12 +237,9 @@ AuthalicLatLon{WGS84Latest}(45.0°, 45.0°)
 struct AuthalicLatLon{Datum,D<:Deg} <: Geographic{Datum}
   lat::D
   lon::D
-  function AuthalicLatLon{Datum,D}(lat, lon) where {Datum,D<:Deg} 
-    new(checklat(lat), fixlon(lon))
-  end
 end
 
-AuthalicLatLon{Datum}(lat::D, lon::D) where {Datum,D<:Deg} = AuthalicLatLon{Datum,float(D)}(lat, lon)
+AuthalicLatLon{Datum}(lat::D, lon::D) where {Datum,D<:Deg} = AuthalicLatLon{Datum,float(D)}(checklat(lat), fixlon(lon))
 AuthalicLatLon{Datum}(lat::Deg, lon::Deg) where {Datum} = AuthalicLatLon{Datum}(promote(lat, lon)...)
 AuthalicLatLon{Datum}(lat::Rad, lon::Rad) where {Datum} = AuthalicLatLon{Datum}(rad2deg(lat), rad2deg(lon))
 AuthalicLatLon{Datum}(lat::Number, lon::Number) where {Datum} = AuthalicLatLon{Datum}(addunit(lat, °), addunit(lon, °))

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -251,7 +251,7 @@ struct AuthalicLatLon{Datum,D<:Deg} <: Geographic{Datum}
   end
 end
 
-AuthalicLatLon{Datum}(lat::D, lon::D) where {Datum,D<:Deg} = AuthalicLatLon{Datum,float(D)}(lat, fixlon(lon))
+AuthalicLatLon{Datum}(lat::D, lon::D) where {Datum,D<:Deg} = AuthalicLatLon{Datum,float(D)}(lat, lon)
 AuthalicLatLon{Datum}(lat::Deg, lon::Deg) where {Datum} = AuthalicLatLon{Datum}(promote(lat, lon)...)
 AuthalicLatLon{Datum}(lat::Rad, lon::Rad) where {Datum} = AuthalicLatLon{Datum}(rad2deg(lat), rad2deg(lon))
 AuthalicLatLon{Datum}(lat::Number, lon::Number) where {Datum} = AuthalicLatLon{Datum}(addunit(lat, °), addunit(lon, °))

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -60,7 +60,7 @@ end
 lentype(::Type{<:GeodeticLatLon{Datum,D}}) where {Datum,D} = Met{numtype(D)}
 
 ==(coords₁::GeodeticLatLon{Datum}, coords₂::GeodeticLatLon{Datum}) where {Datum} =
-  coords₁.lat == coords₂.lat && (coords₁.lon == coords₂.lon || (islon180(coords₁.lon) && coords₁.lon == -coords₂.lon))
+  coords₁.lat == coords₂.lat && coords₁.lon == coords₂.lon
 
 Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeodeticLatLon{Datum}}) where {Datum} =
   GeodeticLatLon{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng))
@@ -143,7 +143,7 @@ lentype(::Type{<:GeodeticLatLonAlt{Datum,D,M}}) where {Datum,D,M} = M
 
 ==(coords₁::GeodeticLatLonAlt{Datum}, coords₂::GeodeticLatLonAlt{Datum}) where {Datum} =
   coords₁.lat == coords₂.lat &&
-  (coords₁.lon == coords₂.lon || (islon180(coords₁.lon) && coords₁.lon == -coords₂.lon)) &&
+  coords₁.lon == coords₂.lon &&
   coords₁.alt == coords₂.alt
 
 Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeodeticLatLonAlt{Datum}}) where {Datum} =
@@ -219,7 +219,7 @@ end
 lentype(::Type{<:GeocentricLatLon{Datum,D}}) where {Datum,D} = Met{numtype(D)}
 
 ==(coords₁::GeocentricLatLon{Datum}, coords₂::GeocentricLatLon{Datum}) where {Datum} =
-  coords₁.lat == coords₂.lat && (coords₁.lon == coords₂.lon || (islon180(coords₁.lon) && coords₁.lon == -coords₂.lon))
+  coords₁.lat == coords₂.lat && coords₁.lon == coords₂.lon
 
 Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeocentricLatLon{Datum}}) where {Datum} =
   GeocentricLatLon{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng))
@@ -273,7 +273,7 @@ end
 lentype(::Type{<:AuthalicLatLon{Datum,D}}) where {Datum,D} = Met{numtype(D)}
 
 ==(coords₁::AuthalicLatLon{Datum}, coords₂::AuthalicLatLon{Datum}) where {Datum} =
-  coords₁.lat == coords₂.lat && (coords₁.lon == coords₂.lon || (islon180(coords₁.lon) && coords₁.lon == -coords₂.lon))
+  coords₁.lat == coords₂.lat && coords₁.lon == coords₂.lon
 
 Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{AuthalicLatLon{Datum}}) where {Datum} =
   AuthalicLatLon{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -40,12 +40,17 @@ end
 """
     checklat(lat)
 Checks if the latitude is in the range `[-90°,90°]` and returns it if yes or throws an error otherwise.
+
+!!! note
+The check has a tolerance of `1e-6°` around +90° and -90°, so if `90° < abs(lat) < 90.000001°` the function returns either +90° or -90° depending on the sign of the input.
 """
 function checklat(lat)
-  if abs(lat) > 90u"°"
+  abslat = abs(lat)
+  T = typeof(abslat)
+  if abslat > (90 + 1e-6) * u"°"
     throw(ArgumentError("the latitude must be in the range [-90°,90°], while $lat was provided"))
   end
-  lat
+  ifelse(abslat > 90u"°", sign(abslat) * T(90), lat)
 end
 """
     fixlon(lon)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -46,16 +46,14 @@ end
 
 """
     checklat(lat)
-Checks if the latitude is in the range `[-90°,90°]` and returns it if yes or throws an error otherwise.
-
-The check has a tolerance of `1e-6°` around +90° and -90°, so if `90° < abs(lat) < 90.000001°` the function returns either +90° or -90° depending on the sign of the input.
+Checks if the latitude is in the range `[-90°,90°]`.
 """
 function checklat(lat)
   abslat = abs(lat)
-  if abslat > 90° + 1e-6°
+  if abslat > 90°
     throw(ArgumentError("the latitude must be in the range [-90°,90°], while $lat was provided"))
   end
-  ifelse(abslat > 90°, oftype(lat, sign(lat) * 90°), lat)
+  lat
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,7 +58,7 @@ Fix the longitude to be in the range `(-180°,180°]`.
 """
 function fixlon(lon) 
   lon = rem(lon, 360°, RoundNearest)
-  ifelse(lon == -180°, 180°, lon)
+  ifelse(lon == -180°, oftype(lon, 180°), lon)
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -45,11 +45,10 @@ The check has a tolerance of `1e-6°` around +90° and -90°, so if `90° < abs(
 """
 function checklat(lat)
   abslat = abs(lat)
-  T = typeof(abslat)
   if abslat > 90° + 1e-6°
     throw(ArgumentError("the latitude must be in the range [-90°,90°], while $lat was provided"))
   end
-  ifelse(abslat > 90°, sign(lat) * T(90), lat)
+  ifelse(abslat > 90°, oftype(lat, sign(lat) * 90°), lat)
 end
 """
     fixlon(lon)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,6 +38,16 @@ function atanpos(y, x)
 end
 
 """
+    checklat(lat)
+Checks if the latitude is in the range `[-90°,90°]` and returns it if yes or throws an error otherwise.
+"""
+function checklat(lat)
+  if abs(lat) > 90u"°"
+    throw(ArgumentError("the latitude must be in the range [-90°,90°]"))
+  end
+  lat
+end
+"""
     fixlon(lon)
 
 Fix the longitude to be in the range `[-180°,180°]`.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -41,16 +41,15 @@ end
     checklat(lat)
 Checks if the latitude is in the range `[-90°,90°]` and returns it if yes or throws an error otherwise.
 
-!!! note
 The check has a tolerance of `1e-6°` around +90° and -90°, so if `90° < abs(lat) < 90.000001°` the function returns either +90° or -90° depending on the sign of the input.
 """
 function checklat(lat)
   abslat = abs(lat)
   T = typeof(abslat)
-  if abslat > (90 + 1e-6) * u"°"
+  if abslat > 90° + 1e-6°
     throw(ArgumentError("the latitude must be in the range [-90°,90°], while $lat was provided"))
   end
-  ifelse(abslat > 90u"°", sign(lat) * T(90), lat)
+  ifelse(abslat > 90°, sign(lat) * T(90), lat)
 end
 """
     fixlon(lon)
@@ -58,8 +57,8 @@ end
 Fix the longitude to be in the range `(-180°,180°]`.
 """
 function fixlon(lon) 
-    lon = rem(lon, 360°, RoundNearest)
-    ifelse(lon == -180°, 180°, lon)
+  lon = rem(lon, 360°, RoundNearest)
+  ifelse(lon == -180°, 180°, lon)
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -46,6 +46,7 @@ end
 
 """
     checklat(lat)
+
 Checks if the latitude is in the range `[-90°,90°]`.
 """
 function checklat(lat)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -50,7 +50,7 @@ function checklat(lat)
   if abslat > (90 + 1e-6) * u"°"
     throw(ArgumentError("the latitude must be in the range [-90°,90°], while $lat was provided"))
   end
-  ifelse(abslat > 90u"°", sign(abslat) * T(90), lat)
+  ifelse(abslat > 90u"°", sign(lat) * T(90), lat)
 end
 """
     fixlon(lon)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,7 +43,7 @@ Checks if the latitude is in the range `[-90°,90°]` and returns it if yes or t
 """
 function checklat(lat)
   if abs(lat) > 90u"°"
-    throw(ArgumentError("the latitude must be in the range [-90°,90°]"))
+    throw(ArgumentError("the latitude must be in the range [-90°,90°], while $lat was provided"))
   end
   lat
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -50,16 +50,12 @@ end
 """
     fixlon(lon)
 
-Fix the longitude to be in the range `[-180°,180°]`.
+Fix the longitude to be in the range `(-180°,180°]`.
 """
-fixlon(lon) = ifelse(-180° ≤ lon ≤ 180°, lon, (lon % 360° + 540°) % 360° - 180°)
-
-"""
-    islon180(lon)
-
-Checks if the longitude is `180°` or `-180°`.
-"""
-islon180(lon) = abs(lon) == 180°
+function fixlon(lon) 
+    lon = rem(lon, 360°, RoundNearest)
+    ifelse(lon == -180°, 180°, lon)
+end
 
 """
     numconvert(T, x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -84,13 +84,6 @@ Converts the unitless `λ` to longitude.
 lam2lon(λ) = rad2deg(λ) * °
 
 """
-    islon180(lon)
-
-Checks if the longitude is `180°` or `-180°`.
-"""
-islon180(lon) = abs(lon) == 180°
-
-"""
     newton(f, df, xₒ; maxiter=10, tol=atol(xₒ))
 
 Newton's method approximates the root of the function `f` using its derivative `df`, 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -49,8 +49,7 @@ end
 Checks if the latitude is in the range `[-90°,90°]`.
 """
 function checklat(lat)
-  abslat = abs(lat)
-  if abslat > 90°
+  if abs(lat) > 90°
     throw(ArgumentError("the latitude must be in the range [-90°,90°], while $lat was provided"))
   end
   lat

--- a/test/crs/constructors.jl
+++ b/test/crs/constructors.jl
@@ -170,6 +170,16 @@
       @test LatLon(T(1) * °, 2 * °) == LatLon(T(1) * °, T(2) * °)
       @test allapprox(LatLon(T(π / 4) * rad, T(π / 4) * rad), LatLon(T(45) * °, T(45) * °))
 
+      # fix longitude
+      @test LatLon(T(0), T(225)) == LatLon(T(0), T(-135))
+      @test LatLon(T(0), T(270)) == LatLon(T(0), T(-90))
+      @test LatLon(T(0), T(315)) == LatLon(T(0), T(-45))
+      @test LatLon(T(0), T(-225)) == LatLon(T(0), T(135))
+      @test LatLon(T(0), T(-270)) == LatLon(T(0), T(90))
+      @test LatLon(T(0), T(-315)) == LatLon(T(0), T(45))
+      @test LatLon(T(0), T(405)) == LatLon(T(0), T(45))
+      @test LatLon(T(0), T(765)) == LatLon(T(0), T(45))
+
       c = LatLon(T(1), T(2))
       @test sprint(show, c) == "GeodeticLatLon{WGS84Latest}(lat: 1.0°, lon: 2.0°)"
       if T === Float32

--- a/test/crs/constructors.jl
+++ b/test/crs/constructors.jl
@@ -189,6 +189,10 @@
       @test_throws ArgumentError LatLon(T(1) * s, T(1) * °)
       @test_throws ArgumentError LatLon(T(1) * °, T(1) * s)
       @test_throws ArgumentError LatLon(T(1) * s, T(1) * s)
+
+      # error: latitude above 90° or below -90°
+      @test_throws ArgumentError LatLon(91, 0)
+      @test_throws ArgumentError LatLon(-91, 0)
     end
 
     @testset "GeodeticLatLonAlt" begin


### PR DESCRIPTION
This PR reintroduces the `checklat` function initially proposed in #121 and improves the `fixlon` function to returns a value in the (-180, 180] range rather than the [-180, 180] one.

This removes the need of the `islon180` function as -180 is converted to 180° at construction.

~~The check is now also enforced in the inner constructor of the various geographic crs types to avoid the possibility of inadvertently skip the check.~~
Given that this check indeed introduces overhead, I moved back the check on the more specialized outer constructor, leaving the fully parametrized inner constructor without checks in case one knows already the inputs he is providing are within bounds (like inside custom `rand` methods).

I had to add some tolerance for the out of bounds of checklat (1e-6° at the moment) as unfortunately two tests in back and forth conversion between geographic and projected spaces were breaking due to rounding errors in computation that ledd to latitude values lower but very close to -90° (e.g. `-90.00000000000003°`, see [this CI run log](https://github.com/JuliaEarth/CoordRefSystems.jl/pull/146/checks?check_run_id=28300894477)).

I still believe that having a check on the inputs is important for ensuring consistency, but I would like to know other opinions on how to handle these potential errors caused by rounding problems.

# Benchmark
The performance actually seems to improve in 1.11, and 1.9 (on windows) in my tests with the code below, which does not rely on custom `rand` anymore to avoid bias and implement basically the same methodology for creating random points without the problems in #147:
```julia
using CoordRefSystems
using CoordRefSystems: Deg, Met
using Unitful: °, m
using BenchmarkTools

function randpoint(::Type{T}) where T <: Union{LatLon, AuthalicLatLon, GeocentricLatLon}
    lat = -90° + rand() * 180°
    lon = -360° + rand() * 2 * 360°
    T(lat, lon)
end
function randpoint(::Type{T}) where T <: LatLonAlt
    lat = -90° + rand() * 180°
    lon = -360° + rand() * 2 * 360°
    alt = rand() * 1m
    T(lat, lon, alt)
end
randpoints(::Type{T}, n) where T = map(i -> randpoint(T), 1:n)

function bench(types)
    for T in types
        println()
        println("#=============== Test $T Begin ==============#")
        println()
        println("Creating 10000 random elements of type $T (generic type, with checks):")
        b = @benchmark $randpoints($T, 10000)
        println()
        display(b)
        println()
        # Test with fully parametrized constructor, skipping checks
        P = T <: LatLonAlt ? T{WGS84Latest, Deg{Float64}, Met{Float64}} : T{WGS84Latest, Deg{Float64}}
        name = T <: LatLonAlt ? "$(T){WGS84Latest, Deg{Float64}, Met{Float64}}" : "$(T){WGS84Latest, Deg{Float64}}"
        println("Creating 10000 random elements of type $(name) (fully parametrized type, no checks):")
        b = @benchmark $randpoints($P, 10000)
        println()
        display(b)
    end
end
```

As it can be seen from the benchmark below, the checks do indeed increase construction time by ~3 times (~4 times in 1.9) in this PR compared to the unchecked inner constructor. It however seems that this implementation with `checklat` and modified `fixlon` is still faster (more so in 1.11) than the current implementation in main. I would still leave both checks for the generic constructor and give this way of skipping checks by using the fully parametrized constructor if ones want to get peak speed and can either ensure inputs are within bounds or does not care about that (probably this should be documented).

## After this PR
### Julia 1.11-rc2 - Windows
```julia-repl
julia> bench([LatLon, LatLonAlt, GeocentricLatLon, AuthalicLatLon])

#=============== Test GeodeticLatLon Begin ==============#

Creating 10000 random elements of type GeodeticLatLon (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  158.700 μs …   5.989 ms  ┊ GC (min … max): 0.00% … 96.35%
 Time  (median):     162.800 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   179.979 μs ± 118.746 μs  ┊ GC (mean ± σ):  4.29% ±  6.79%

  ▄█▇▄▅▁▂▁▁▁     ▂▄▃▃▂▁ ▁                                       ▁
  █████████████▆▇███████████▇▇▇▇▆▇▇▆▇▇▆▅▆▆▆▆▄▅▆▆▆▇▆█▇▄▄▅▅▄▄▄▄▃▄ █
  159 μs        Histogram: log(frequency) by time        272 μs <

 Memory estimate: 156.31 KiB, allocs estimate: 3.

Creating 10000 random elements of type GeodeticLatLon{WGS84Latest, Deg{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  54.900 μs …   7.974 ms  ┊ GC (min … max): 0.00% … 98.52%
 Time  (median):     56.800 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   71.802 μs ± 135.381 μs  ┊ GC (mean ± σ):  8.96% ±  6.22%

  █▆▅▄▂▁              ▄▄▃▃▂▂▁ ▁                                ▁
  ███████▇▇▅▇▆▆▅▆▆▅▅▆▆███████████▇▇▆▇▇▇▆▇▆▆▇▇▆▇▆▅▅▆▅▅▂▃▃▂▂▂▃▂▃ █
  54.9 μs       Histogram: log(frequency) by time       133 μs <

 Memory estimate: 156.31 KiB, allocs estimate: 3.

#=============== Test GeodeticLatLonAlt Begin ==============#

Creating 10000 random elements of type GeodeticLatLonAlt (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  166.600 μs …  10.119 ms  ┊ GC (min … max): 0.00% … 97.47%
 Time  (median):     171.100 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   192.962 μs ± 148.664 μs  ┊ GC (mean ± σ):  5.40% ±  7.99%

  █▆▄▂▁▁  ▅▃▂▁▁▁                                                ▁
  █████████████████▇███▆▅▅▄▄▅▅▄▄▅▄▄▄▅▄▄▃▄▄▁▃▁▄▁▁▁▃▁▁▁▁▃▄▁▃▁▁▁▁▃ █
  167 μs        Histogram: log(frequency) by time        489 μs <

 Memory estimate: 234.44 KiB, allocs estimate: 3.

Creating 10000 random elements of type GeodeticLatLonAlt{WGS84Latest, Deg{Float64}, Met{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  55.000 μs …   7.404 ms  ┊ GC (min … max):  0.00% … 98.35%
 Time  (median):     57.100 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   74.487 μs ± 132.485 μs  ┊ GC (mean ± σ):  10.83% ±  7.49%

  █▆▄▂▂▁ ▁        ▄▄▃▁                                         ▁
  ███████████▆▆▆▅▆█████▇▇▇▇▆▆▆▅▆▅▆▅▅▅▅▅▄▁▄▄▃▅▄▅▄▄▃▅▄▁▄▃▃▄▄▄▄▄▇ █
  55 μs         Histogram: log(frequency) by time       201 μs <

 Memory estimate: 234.44 KiB, allocs estimate: 3.

#=============== Test GeocentricLatLon Begin ==============#

Creating 10000 random elements of type GeocentricLatLon (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  158.200 μs …   9.036 ms  ┊ GC (min … max): 0.00% … 97.39%
 Time  (median):     162.200 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   180.138 μs ± 135.100 μs  ┊ GC (mean ± σ):  4.41% ±  6.80%

  ▅█▅▅▃▃▂▂▁▁   ▅▄▃▃▂ ▁                                          ▂
  ██████████████████████▇▇▇▇▇▇▆▇█▇▆▇▇▆▅▆▅▆▆▆▆▅▅▇▅▅▅▅▅▅▅▄▃▄▁▄▄▃▃ █
  158 μs        Histogram: log(frequency) by time        293 μs <

 Memory estimate: 156.31 KiB, allocs estimate: 3.

Creating 10000 random elements of type GeocentricLatLon{WGS84Latest, Deg{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  54.800 μs …   7.896 ms  ┊ GC (min … max): 0.00% … 98.60%
 Time  (median):     56.400 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   70.358 μs ± 123.537 μs  ┊ GC (mean ± σ):  8.59% ±  6.23%

  █▆▃▃▁            ▄▄▃▂▁                                       ▁
  █████████▇██▇▆▆▅▇█████▇▇▆▇▇▅▇▆▆▆▅▅▅▅▄▅▅▆▄▄▅▄▅▃▄▄▄▃▄▃▃▄▃▃▂▃▄▄ █
  54.8 μs       Histogram: log(frequency) by time       148 μs <

 Memory estimate: 156.31 KiB, allocs estimate: 3.

#=============== Test AuthalicLatLon Begin ==============#

Creating 10000 random elements of type AuthalicLatLon (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  158.300 μs …   5.586 ms  ┊ GC (min … max): 0.00% … 96.06%
 Time  (median):     162.800 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   178.875 μs ± 103.934 μs  ┊ GC (mean ± σ):  3.95% ±  6.77%

  ▄█▅▅▃▂▂▂▁▁  ▁▄▂▂▁ ▁                                           ▁
  ████████████████████▇▇▇▇▇▆▇▇█▇▇▆▇▆▆▅▅▄▅▅▅▅▃▃▃▄▄▃▂▄▃▄▄▅▄▄▂▃▄▃▅ █
  158 μs        Histogram: log(frequency) by time        301 μs <

 Memory estimate: 156.31 KiB, allocs estimate: 3.

Creating 10000 random elements of type AuthalicLatLon{WGS84Latest, Deg{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  54.900 μs …  13.777 ms  ┊ GC (min … max): 0.00% … 99.17%
 Time  (median):     56.400 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   70.921 μs ± 164.284 μs  ┊ GC (mean ± σ):  9.16% ±  6.22%

  █▆▄▃▂▁             ▁▃▄▃▂▁▁                                   ▁
  ███████▇▇▇▇▆▄▇▆▇▅▆▆████████▇▇████▇▇▆▆▆▆▆▆▆▅▅▅▄▅▅▅▅▄▄▄▅▅▄▄▃▄▅ █
  54.9 μs       Histogram: log(frequency) by time       134 μs <

 Memory estimate: 156.31 KiB, allocs estimate: 3.
```

### Julia 1.9.4 - Windows
```julia-repl
julia> bench([LatLon, LatLonAlt, GeocentricLatLon, AuthalicLatLon])

#=============== Test GeodeticLatLon Begin ==============#

Creating 10000 random elements of type GeodeticLatLon (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  213.500 μs …   3.918 ms  ┊ GC (min … max): 0.00% … 91.68%
 Time  (median):     226.500 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   243.076 μs ± 110.634 μs  ┊ GC (mean ± σ):  2.20% ±  4.71%

  ▇█▅▆▄▄▄▂▁▁▁▄▇▅▅▄▃▃▃▁▂▂▁▁▁▁  ▁                                 ▂
  ████████████████████████████████▇▇█▇▇█▇████▇▆▆▅▆▆▆▅▆▇▆▅▇▇▅▆▃▆ █
  214 μs        Histogram: log(frequency) by time        360 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.

Creating 10000 random elements of type GeodeticLatLon{WGS84Latest, Deg{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  55.500 μs …  3.625 ms  ┊ GC (min … max): 0.00% … 96.65%
 Time  (median):     58.000 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   73.320 μs ± 98.137 μs  ┊ GC (mean ± σ):  6.46% ±  5.14%

  █▇▅▂▂▂▁▁         ▄▆▅▃▂▁▁▁                                   ▂
  ████████▇██▇▇▅▇▇▄█████████▇▇▇▇▆▆▇▆▆▆▅▆▅▆▆▆▅▅▅▅▅▆▅▆▄▅▅▄▄▃▄▄▅ █
  55.5 μs      Histogram: log(frequency) by time       146 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.

#=============== Test GeodeticLatLonAlt Begin ==============#

Creating 10000 random elements of type GeodeticLatLonAlt (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  215.700 μs …   5.852 ms  ┊ GC (min … max): 0.00% … 95.38%
 Time  (median):     224.300 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   248.930 μs ± 136.460 μs  ┊ GC (mean ± σ):  2.89% ±  5.53%

  ██▇▅▄▃▂▂▁▁▁ ▂▆▄▅▃▂▂▂▂▁▁▁▁                                     ▂
  █████████████████████████████▇▇▇▇▇▇▆▇▇▆▇▇██▇▇▅▅▆▆▄▅▄▄▄▄▅▄▄▄▅▅ █
  216 μs        Histogram: log(frequency) by time        414 μs <

 Memory estimate: 234.42 KiB, allocs estimate: 2.

Creating 10000 random elements of type GeodeticLatLonAlt{WGS84Latest, Deg{Float64}, Met{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  66.700 μs …   6.737 ms  ┊ GC (min … max): 0.00% … 98.05%
 Time  (median):     68.700 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   87.168 μs ± 114.553 μs  ┊ GC (mean ± σ):  6.80% ±  6.04%

  █▆▃▂▁▁      ▁▁    ▂▄▄▂                                       ▁
  █████████▇▆████▅▆▆█████▇▇▇▇▇▇▅▆▅▅▅▆▆▆▅▆▆▆▅▅▄▅▅▅▄▃▄▅▄▅▅▄▄▄▄▅▃ █
  66.7 μs       Histogram: log(frequency) by time       199 μs <

 Memory estimate: 234.42 KiB, allocs estimate: 2.

#=============== Test GeocentricLatLon Begin ==============#

Creating 10000 random elements of type GeocentricLatLon (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  212.600 μs …   5.737 ms  ┊ GC (min … max): 0.00% … 95.31%
 Time  (median):     219.000 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   234.399 μs ± 117.583 μs  ┊ GC (mean ± σ):  2.02% ±  4.43%

  ▃█▇▆▅▄▃▃▂▂▁▁▁▄▃▂▂▁▁▁  ▁                                       ▂
  ████████████████████████████▇▇▇▇▇▇▆▆▄▆▆▅▅▆▇▅▅▅▆▅▆▆▅▅▅▆▇▅▅▃▅▄▄ █
  213 μs        Histogram: log(frequency) by time        352 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.

Creating 10000 random elements of type GeocentricLatLon{WGS84Latest, Deg{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  55.300 μs …  3.585 ms  ┊ GC (min … max): 0.00% … 96.94%
 Time  (median):     57.400 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   66.606 μs ± 77.183 μs  ┊ GC (mean ± σ):  5.21% ±  4.97%

  ▆█▆▅▃▂▁▁▁▁                ▂▁▃▂▁                             ▁
  ████████████▇▆█▇▆▅▆▅▅▅▅▇▇█████████▇▇▇▇▇▆▇▇▆▆▆▅▅▅▆▅▅▄▄▅▄▄▅▄▅ █
  55.3 μs      Histogram: log(frequency) by time       119 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.

#=============== Test AuthalicLatLon Begin ==============#

Creating 10000 random elements of type AuthalicLatLon (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  213.600 μs …   7.194 ms  ┊ GC (min … max): 0.00% … 96.19%
 Time  (median):     218.400 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   232.503 μs ± 126.267 μs  ┊ GC (mean ± σ):  2.01% ±  4.38%

  ▄█▇▅▅▃▃▃▂▁▂▁ ▂▃▂▂▂▁ ▁                                         ▂
  ██████████████████████▇█▇▇▇██▆█▇▇▇▆▇▇▆▆▇▅▇▆▆▆▇▆▆▅▆▆▅▇█▆▄▃▅▅▁▄ █
  214 μs        Histogram: log(frequency) by time        346 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.

Creating 10000 random elements of type AuthalicLatLon{WGS84Latest, Deg{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  55.200 μs …  3.361 ms  ┊ GC (min … max): 0.00% … 95.16%
 Time  (median):     57.200 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   66.459 μs ± 74.773 μs  ┊ GC (mean ± σ):  4.94% ±  4.95%

  ▇█▅▃▂▁           ▂▃▃▂▁                                      ▁
  ████████▇██▇▇▇▇▅▆██████▇▇▆▆▆▆▅▆▆▆▅▅▅▄▅▆▄▅▅▃▂▅▅▅▅▄▃▅▃▄▄▃▄▄▄▆ █
  55.2 μs      Histogram: log(frequency) by time       148 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.
```

## Before PR (main)
### Julia 1.11-rc2 - Windows
```julia-repl
julia> bench([LatLon, LatLonAlt, GeocentricLatLon, AuthalicLatLon])

#=============== Test GeodeticLatLon Begin ==============#

Creating 10000 random elements of type GeodeticLatLon (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  248.400 μs …   8.571 ms  ┊ GC (min … max): 0.00% … 96.19%
 Time  (median):     256.500 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   275.683 μs ± 153.088 μs  ┊ GC (mean ± σ):  3.50% ±  6.79%

  █▃▆▃▃▃▁▆▅▄▃▃▂▂▁▁                                              ▂
  █████████████████▇██▇▇▆▇▇▆▅▆▅▅▅▄▅▄▁▄▄▄▄▃▅▁▄▅▄▃▃▅▅▃▄▁▁▄▁▃▁▃▁▁▃ █
  248 μs        Histogram: log(frequency) by time        478 μs <

 Memory estimate: 156.31 KiB, allocs estimate: 3.

Creating 10000 random elements of type GeodeticLatLon{WGS84Latest, Deg{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  55.000 μs …  11.977 ms  ┊ GC (min … max): 0.00% … 99.12%
 Time  (median):     57.200 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   74.165 μs ± 162.947 μs  ┊ GC (mean ± σ):  9.30% ±  6.23%

  █▆▄▂▂▁▁   ▁     ▅▄▄▂▁    ▁▁▁                                 ▁
  ████████▇██▇▇▆▆████████▇▇████▇▇▅▆▅▄▅▄▅▅▃▄▃▅▃▄▄▃▅▃▅▄▄▅▄▂▄▄▅▇▆ █
  55 μs         Histogram: log(frequency) by time       153 μs <

 Memory estimate: 156.31 KiB, allocs estimate: 3.

#=============== Test GeodeticLatLonAlt Begin ==============#

Creating 10000 random elements of type GeodeticLatLonAlt (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  251.800 μs …   6.544 ms  ┊ GC (min … max): 0.00% … 94.92%
 Time  (median):     254.000 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   277.546 μs ± 138.184 μs  ┊ GC (mean ± σ):  4.18% ±  7.95%

  █▄▃▅▂▁▁                                                       ▁
  ████████▇▇▇▅▄▁▄▃▁▅▁▃▁▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▃▁▁▁▁▃▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▄ █
  252 μs        Histogram: log(frequency) by time        1.1 ms <

 Memory estimate: 234.44 KiB, allocs estimate: 3.

Creating 10000 random elements of type GeodeticLatLonAlt{WGS84Latest, Deg{Float64}, Met{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  55.100 μs …   7.335 ms  ┊ GC (min … max):  0.00% … 98.31%
 Time  (median):     56.200 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   74.150 μs ± 135.312 μs  ┊ GC (mean ± σ):  10.69% ±  7.44%

  █▅▂▁▁▁▁           ▃▃▃▁▁                                      ▁
  ████████▆▆▄▅▆▆▆▄▆▅█████▇▇▇▇▇▆▅▅▆▆▆▅▆▅▄▅▅▄▃▅▅▄▃▂▄▃▄▃▃▃▄▅▃▃▂▄▃ █
  55.1 μs       Histogram: log(frequency) by time       185 μs <

 Memory estimate: 234.44 KiB, allocs estimate: 3.

#=============== Test GeocentricLatLon Begin ==============#

Creating 10000 random elements of type GeocentricLatLon (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  250.400 μs …   4.696 ms  ┊ GC (min … max): 0.00% … 93.40%
 Time  (median):     257.200 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   271.079 μs ± 109.544 μs  ┊ GC (mean ± σ):  3.04% ±  6.76%

  █▄▇▄▃▃▂▂▂▅▂▁▁▁                                                ▂
  ██████████████████▆▇▆▇▆▆▆▆▅▄▅▅▄▅▃▅▁▅▅▁▄▁▆▄▅▅▅▄▁▅▁▄▃▃▃▃▃▄▃▁▃▁▃ █
  250 μs        Histogram: log(frequency) by time        447 μs <

 Memory estimate: 156.31 KiB, allocs estimate: 3.

Creating 10000 random elements of type GeocentricLatLon{WGS84Latest, Deg{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  55.000 μs …  10.956 ms  ┊ GC (min … max): 0.00% … 98.94%
 Time  (median):     56.600 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   69.951 μs ± 142.007 μs  ┊ GC (mean ± σ):  8.85% ±  6.11%

  █▆▆▄▃▂▁               ▁▄▃▃▃▁                                 ▁
  █████████▆▅▅▆▅▅▅▅▄▃▄▃▄███████▇▇▇▇█▇▇▇▇▆▅▅▆▅▆▆▅▅▆▅▅▅▅▅▅▅▅▅▄▄▄ █
  55 μs         Histogram: log(frequency) by time       124 μs <

 Memory estimate: 156.31 KiB, allocs estimate: 3.

#=============== Test AuthalicLatLon Begin ==============#

Creating 10000 random elements of type AuthalicLatLon (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  250.200 μs …   4.551 ms  ┊ GC (min … max): 0.00% … 93.22%
 Time  (median):     253.000 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   269.488 μs ± 117.688 μs  ┊ GC (mean ± σ):  3.26% ±  6.84%

  ▇█▃▃▄▂▃▂▂▁▁  ▄▄▂▁▂▁                                           ▂
  ████████████▇██████████▇█▇▇▇▆▇▆▅▆▅▅▅▆▅▅▅▅▅▄▄▅▄▅▅▅▄▃▃▅▁▁▄▄▃▃▄▃ █
  250 μs        Histogram: log(frequency) by time        379 μs <

 Memory estimate: 156.31 KiB, allocs estimate: 3.

Creating 10000 random elements of type AuthalicLatLon{WGS84Latest, Deg{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  54.900 μs …   9.739 ms  ┊ GC (min … max): 0.00% … 98.42%
 Time  (median):     56.700 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   76.317 μs ± 136.797 μs  ┊ GC (mean ± σ):  8.22% ±  6.24%

  █▆▃▂▂          ▂▄▂▂▁                  ▂▃▂▁▁                  ▁
  ███████▇█▇▇▇▇▆▆█████▇▇▆▆▆▆▆▆▆▃▃▃▅▃▅▄▃█████████▇███▇█▇▇▆▅▅▆▅▅ █
  54.9 μs       Histogram: log(frequency) by time       151 μs <

 Memory estimate: 156.31 KiB, allocs estimate: 3.
```
### Julia 1.9.4 - Windows
```julia-repl
julia> bench([LatLon, LatLonAlt, GeocentricLatLon, AuthalicLatLon])

#=============== Test GeodeticLatLon Begin ==============#

Creating 10000 random elements of type GeodeticLatLon (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  251.100 μs …  4.042 ms  ┊ GC (min … max): 0.00% … 91.25%
 Time  (median):     260.100 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   275.670 μs ± 94.495 μs  ┊ GC (mean ± σ):  1.60% ±  4.45%

  ▄█▆▂▄▅▃▂▃▂▁ ▂▂▁▂▄▃▄▄▅▄▃▂▂▂▂▁ ▁         ▂▁                    ▂
  ██████████████████████████████████▇▇▇████▇▇▇▆▆▆▆▆▆▅▆▆▅▄▅▄▅▁▆ █
  251 μs        Histogram: log(frequency) by time       363 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.

Creating 10000 random elements of type GeodeticLatLon{WGS84Latest, Deg{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  55.500 μs …  3.384 ms  ┊ GC (min … max): 0.00% … 95.09%
 Time  (median):     58.100 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   74.788 μs ± 97.143 μs  ┊ GC (mean ± σ):  6.25% ±  5.13%

  ██▅▃▂▁▁▁ ▁      ▁▃▅▅▅▃▂▂▁▁▁                                 ▂
  ████████████▇█▇████████████████▆▆▇▇▇▇▇▆▇▇▇███▇▆▆▅▆▄▄▄▅▄▄▅▄▄ █
  55.5 μs      Histogram: log(frequency) by time       145 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.

#=============== Test GeodeticLatLonAlt Begin ==============#

Creating 10000 random elements of type GeodeticLatLonAlt (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  251.500 μs …   3.506 ms  ┊ GC (min … max): 0.00% … 89.08%
 Time  (median):     256.800 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   282.424 μs ± 118.287 μs  ┊ GC (mean ± σ):  2.25% ±  5.34%

  █▅▄▄▂▂▂▁▂▅▃▄▃▂▂▁                                              ▂
  ████████████████████▇█▇█▇▇▆▆▆▅▅▅▅▄▅▅▅▅▄▆▄▄▄▅▄▄▄▄▄▄▁▃▄▄▄▄▄▅▄▃▄ █
  252 μs        Histogram: log(frequency) by time        535 μs <

 Memory estimate: 234.42 KiB, allocs estimate: 2.

Creating 10000 random elements of type GeodeticLatLonAlt{WGS84Latest, Deg{Float64}, Met{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  66.800 μs …   3.209 ms  ┊ GC (min … max): 0.00% … 95.98%
 Time  (median):     69.000 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   88.689 μs ± 100.244 μs  ┊ GC (mean ± σ):  6.66% ±  6.10%

  █▇▃▂▁▁▁            ▁ ▁▃▃▂▁▁▂▄▃▂                              ▁
  ██████████▇▇▇▇▇▇▇▇▆█████████████▇▇▆▆▆▅▅▅▅▄▅▅▅▄▆▄▅▄▂▄▅▄▆▅▅▄▅▄ █
  66.8 μs       Histogram: log(frequency) by time       180 μs <

 Memory estimate: 234.42 KiB, allocs estimate: 2.

#=============== Test GeocentricLatLon Begin ==============#

Creating 10000 random elements of type GeocentricLatLon (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  251.600 μs …  3.623 ms  ┊ GC (min … max): 0.00% … 91.22%
 Time  (median):     255.300 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   275.987 μs ± 98.980 μs  ┊ GC (mean ± σ):  1.61% ±  4.43%

  █▇▃▅▃▂▃▁▁▂▃▆▅▃▃▃▂▂▂▂▁▁▂▂▁ ▁                                  ▂
  ████████████████████████████████▇▆█▇▆▆▆▇▇▅▆▇▇▅▆▅▄▆▄▆▄▅▄▄▅▁▄▅ █
  252 μs        Histogram: log(frequency) by time       403 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.

Creating 10000 random elements of type GeocentricLatLon{WGS84Latest, Deg{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  55.400 μs …  4.485 ms  ┊ GC (min … max): 0.00% … 96.15%
 Time  (median):     58.700 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   73.396 μs ± 97.265 μs  ┊ GC (mean ± σ):  6.02% ±  5.09%

  ▆█▅▄▄▃▃▃▃▁      ▂▃▃▃▃▃▃▁▁▁▁▁                                ▁
  ███████████▇▇▇▆▅█████████████▇▇▆▅▅▅▅▅▅▆▆▇▇▆▄▂▅▅▃▅▅▅▅▅▃▅▆▄▄▅ █
  55.4 μs      Histogram: log(frequency) by time       155 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.

#=============== Test AuthalicLatLon Begin ==============#

Creating 10000 random elements of type AuthalicLatLon (generic type, with checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  250.600 μs …  3.409 ms  ┊ GC (min … max): 0.00% … 90.88%
 Time  (median):     253.800 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   268.281 μs ± 92.831 μs  ┊ GC (mean ± σ):  1.64% ±  4.46%

  ▄█▇▃▂▃▄▂▂▂▁▁       ▁▄▅▃▃▂▂▁▁▁                                ▁
  ██████████████▇▇██▆██████████████▇▇▇▆▆▆▇▆▇▇▆▆▅▆▆▆▆▅▅▄▄▄▅▃▄▅▄ █
  251 μs        Histogram: log(frequency) by time       334 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.

Creating 10000 random elements of type AuthalicLatLon{WGS84Latest, Deg{Float64}} (fully parametrized type, no checks):

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  55.600 μs …  4.659 ms  ┊ GC (min … max): 0.00% … 97.70%
 Time  (median):     58.000 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   72.149 μs ± 98.845 μs  ┊ GC (mean ± σ):  6.22% ±  5.09%

  ▇█▅▄▂▂▂▁▁          ▂▄▃▄▃▁▃▂▂▂▁                              ▁
  █████████████▇▇▇▆▆▅████████████▇█▇▆▇▆▆▆▆▆▅▆▅▅▆▅▆▅▅▆▅▄▅▄▄▅▂▅ █
  55.6 μs      Histogram: log(frequency) by time       137 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.
```