### PR TITLE
Add `phi2lat` and `lam2lon`

### DIFF
--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -290,7 +290,7 @@ function Base.convert(::Type{LatLon{Datum}}, coords::GeocentricLatLon{Datum}) wh
   ϕ′ = ustrip(deg2rad(coords.lat))
   e² = oftype(ϕ′, eccentricity²(ellipsoid(Datum)))
   ϕ = atan(1 / (1 - e²) * tan(ϕ′))
-  LatLon{Datum}(rad2deg(ϕ) * °, coords.lon)
+  LatLon{Datum}(phi2lat(ϕ), coords.lon)
 end
 
 # reference code: https://github.com/OSGeo/PROJ/blob/master/src/projections/healpix.cpp#L230
@@ -346,7 +346,7 @@ function Base.convert(::Type{LatLon{Datum}}, coords::AuthalicLatLon{Datum}) wher
   β = ustrip(deg2rad(coords.lat))
   e² = oftype(β, eccentricity²(ellipsoid(Datum)))
   ϕ = auth2geod(β, e²)
-  LatLon{Datum}(rad2deg(ϕ) * °, coords.lon)
+  LatLon{Datum}(phi2lat(ϕ), coords.lon)
 end
 
 # reference code: https://github.com/OSGeo/PROJ/blob/master/src/conversions/cart.cpp
@@ -411,7 +411,7 @@ function Base.convert(::Type{LatLonAlt{Datum}}, coords::Cartesian{Datum,3}) wher
   N = a / sqrt(1 - e² * sin(ϕ)^2)
   h = p / cos(ϕ) - N
 
-  LatLonAlt{Datum}(rad2deg(ϕ) * °, rad2deg(λ) * °, h * m)
+  LatLonAlt{Datum}(phi2lat(ϕ), lam2lon(λ), h * m)
 end
 
 # datum conversion

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -87,7 +87,7 @@ function Base.convert(::Type{LatLon{Datum}}, coords::C) where {Datum,C<:Projecte
   y = coords.y / a
   fx, fy = formulas(C, T)
   λ, ϕ = projinv(fx, fy, x, y, x, y)
-  LatLon{Datum}(rad2deg(ϕ) * °, rad2deg(λ) * °)
+  LatLon{Datum}(phi2lat(ϕ), lam2lon(λ))
 end
 
 Base.convert(C::Type{<:Projected{Datumₜ}}, coords::LatLon{Datumₛ}) where {Datumₜ,Datumₛ} =

--- a/src/crs/projected/eqareacylindrical.jl
+++ b/src/crs/projected/eqareacylindrical.jl
@@ -153,7 +153,7 @@ function Base.convert(::Type{LatLon{Datum}}, coords::EqualAreaCylindrical{latₜ
   β = asin(q / qₚ)
   ϕ = auth2geod(β, e²)
 
-  LatLon{Datum}(rad2deg(ϕ) * °, rad2deg(λ) * °)
+  LatLon{Datum}(phi2lat(ϕ), lam2lon(λ))
 end
 
 # ----------

--- a/src/crs/projected/eqdistcylindrical.jl
+++ b/src/crs/projected/eqdistcylindrical.jl
@@ -80,7 +80,7 @@ function Base.convert(::Type{LatLon{Datum}}, coords::EquidistantCylindrical{lat�
   λ = x / (cos(ϕₜₛ) * a)
   ϕ = y / a
 
-  LatLon{Datum}(rad2deg(ϕ) * °, rad2deg(λ) * °)
+  LatLon{Datum}(phi2lat(ϕ), lam2lon(λ))
 end
 
 # ----------

--- a/src/crs/projected/mercator.jl
+++ b/src/crs/projected/mercator.jl
@@ -84,7 +84,7 @@ function Base.convert(::Type{LatLon{Datum}}, coords::Mercator{Datum}) where {Dat
   λ = x / a
   ϕ = atan(τ)
 
-  LatLon{Datum}(rad2deg(ϕ) * °, rad2deg(λ) * °)
+  LatLon{Datum}(phi2lat(ϕ), lam2lon(λ))
 end
 
 # ----------

--- a/src/crs/projected/orthographic.jl
+++ b/src/crs/projected/orthographic.jl
@@ -156,7 +156,7 @@ function Base.convert(::Type{LatLon{Datum}}, coords::C) where {latₒ,lonₒ,Dat
   λₒ = T(ustrip(deg2rad(lonₒ)))
   ϕₒ = T(ustrip(deg2rad(latₒ)))
   λ, ϕ = sphericalinv(x, y, λₒ, ϕₒ)
-  LatLon{Datum}(rad2deg(ϕ) * °, rad2deg(λ) * °)
+  LatLon{Datum}(phi2lat(ϕ), lam2lon(λ))
 end
 
 function Base.convert(::Type{LatLon{Datum}}, coords::C) where {latₒ,lonₒ,Datum,C<:Orthographic{latₒ,lonₒ,false,Datum}}
@@ -169,7 +169,7 @@ function Base.convert(::Type{LatLon{Datum}}, coords::C) where {latₒ,lonₒ,Dat
   λₛ, ϕₛ = sphericalinv(x, y, λₒ, ϕₒ)
   fx, fy = formulas(C, T)
   λ, ϕ = projinv(fx, fy, x, y, λₛ, ϕₛ)
-  LatLon{Datum}(rad2deg(ϕ) * °, rad2deg(λ) * °)
+  LatLon{Datum}(phi2lat(ϕ), lam2lon(λ))
 end
 
 # ----------

--- a/src/crs/projected/robinson.jl
+++ b/src/crs/projected/robinson.jl
@@ -162,7 +162,7 @@ function Base.convert(::Type{LatLon{Datum}}, coords::Robinson{Datum}) where {Dat
     ϕ = deg2rad(5 * (i - 1) + z) * sign(y)
   end
 
-  LatLon{Datum}(rad2deg(ϕ) * °, rad2deg(λ) * °)
+  LatLon{Datum}(phi2lat(ϕ), lam2lon(λ))
 end
 
 # ----------

--- a/src/crs/projected/transversemercator.jl
+++ b/src/crs/projected/transversemercator.jl
@@ -150,7 +150,7 @@ function Base.convert(::Type{LatLon{Datum}}, coords::TransverseMercator{k₀,lat
   λ = Ce + λₒ
   ϕ = gatg(cgb, Cn)
 
-  LatLon{Datum}(rad2deg(ϕ) * °, rad2deg(λ) * °)
+  LatLon{Datum}(phi2lat(ϕ), lam2lon(λ))
 end
 
 # ----------

--- a/src/crs/projected/webmercator.jl
+++ b/src/crs/projected/webmercator.jl
@@ -67,7 +67,7 @@ function Base.convert(::Type{LatLon{Datum}}, coords::WebMercator{Datum}) where {
   a = oftype(x, majoraxis(🌎))
   λ = x / a
   ϕ = atan(sinh(y / a))
-  LatLon{Datum}(rad2deg(ϕ) * °, rad2deg(λ) * °)
+  LatLon{Datum}(phi2lat(ϕ), lam2lon(λ))
 end
 
 # ----------

--- a/src/crs/projected/winkeltripel.jl
+++ b/src/crs/projected/winkeltripel.jl
@@ -84,7 +84,7 @@ function Base.convert(::Type{LatLon{Datum}}, coords::C) where {lat₁,Datum,C<:W
     fx, fy = formulas(C, T)
     projinv(fx, fy, x, y, x, y; tol)
   end
-  LatLon{Datum}(rad2deg(ϕ) * °, rad2deg(λ) * °)
+  LatLon{Datum}(phi2lat(ϕ), lam2lon(λ))
 end
 
 # ----------

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -45,6 +45,21 @@ Fix the longitude to be in the range `[-180°,180°]`.
 fixlon(lon) = ifelse(-180° ≤ lon ≤ 180°, lon, (lon % 360° + 540°) % 360° - 180°)
 
 """
+    phi2lat(ϕ)
+
+Converts the unitless `ϕ` to latitude and adjusts it to the range `[-90,90]`
+to fix floating-point errors.
+"""
+phi2lat(ϕ) = clamp(rad2deg(ϕ) * °, -90°, 90°)
+
+"""
+    lam2lon(λ)
+
+Converts the unitless `λ` to longitude.
+"""
+lam2lon(λ) = rad2deg(λ) * °
+
+"""
     islon180(lon)
 
 Checks if the longitude is `180°` or `-180°`.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,6 +28,13 @@ addunit(x::Number, u) = x * u
 addunit(x::Quantity, u) = throw(ArgumentError("invalid units for coordinates, please check the documentation"))
 
 """
+    numconvert(T, x)
+
+Converts the number type of quantity `x` to `T`.
+"""
+numconvert(::Type{T}, x::Quantity{S,D,U}) where {T,S,D,U} = convert(Quantity{T,D,U}, x)
+
+"""
     atanpos(x, y)
 
 Adjusts the interval of values returned by the `atan(y, x)` function from `[-π,π]` to `[0,2π]`.
@@ -65,13 +72,6 @@ lam2lon(λ) = rad2deg(λ) * °
 Checks if the longitude is `180°` or `-180°`.
 """
 islon180(lon) = abs(lon) == 180°
-
-"""
-    numconvert(T, x)
-
-Converts the number type of quantity `x` to `T`.
-"""
-numconvert(::Type{T}, x::Quantity{S,D,U}) where {T,S,D,U} = convert(Quantity{T,D,U}, x)
 
 """
     newton(f, df, xₒ; maxiter=10, tol=atol(xₒ))


### PR DESCRIPTION
This PR fixes floating-point errors in the inverse methods. It is a preparation for PR #146.