### PR TITLE
Refactor `rand` implementation

### DIFF
--- a/src/crs.jl
+++ b/src/crs.jl
@@ -130,11 +130,11 @@ tol(coords::CRS) = tol(convert(Cartesian, coords))
 # RAND METHODS
 # -------------
 
-Random.rand(C::Type{<:CRS}) = rand(Random.default_rng(), C)
+Random.rand(::Type{C}) where {C<:CRS} = rand(Random.default_rng(), C)
 
-Random.rand(C::Type{<:CRS}, n::Int) = rand(Random.default_rng(), C, n)
+Random.rand(::Type{C}, n::Int) where {C<:CRS} = rand(Random.default_rng(), C, n)
 
-Random.rand(rng::Random.AbstractRNG, C::Type{<:CRS}, n::Int) = [rand(rng, C) for _ in 1:n]
+Random.rand(rng::Random.AbstractRNG, ::Type{C}, n::Int) where {C<:CRS} = [rand(rng, C) for _ in 1:n]
 
 # -----------
 # IO METHODS

--- a/src/crs.jl
+++ b/src/crs.jl
@@ -126,6 +126,16 @@ The result inherits the unit of the `coords` after conversion to [`Cartesian`](@
 """
 tol(coords::CRS) = tol(convert(Cartesian, coords))
 
+# -------------
+# RAND METHODS
+# -------------
+
+Random.rand(C::Type{<:CRS}) = rand(Random.default_rng(), C)
+
+Random.rand(C::Type{<:CRS}, n::Int) = rand(Random.default_rng(), C, n)
+
+Random.rand(rng::Random.AbstractRNG, C::Type{<:CRS}, n::Int) = [rand(rng, C) for _ in 1:n]
+
 # -----------
 # IO METHODS
 # -----------

--- a/src/crs/basic.jl
+++ b/src/crs/basic.jl
@@ -142,12 +142,12 @@ function tol(coords::Cartesian)
   atol(numtype(Q)) * unit(Q)
 end
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Cartesian{Datum,N}}) where {Datum,N} =
+Random.rand(rng::Random.AbstractRNG, ::Type{Cartesian{Datum,N}}) where {Datum,N} =
   Cartesian{Datum}(ntuple(i -> rand(rng), N)...)
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Cartesian2D}) = rand(rng, Cartesian2D{NoDatum})
+Random.rand(rng::Random.AbstractRNG, ::Type{Cartesian2D}) = rand(rng, Cartesian2D{NoDatum})
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Cartesian3D}) = rand(rng, Cartesian3D{NoDatum})
+Random.rand(rng::Random.AbstractRNG, ::Type{Cartesian3D}) = rand(rng, Cartesian3D{NoDatum})
 
 _coords(coords::Cartesian) = getfield(coords, :coords)
 
@@ -215,10 +215,9 @@ lentype(::Type{<:Polar{Datum,L}}) where {Datum,L} = L
 
 ==(coords₁::Polar{Datum}, coords₂::Polar{Datum}) where {Datum} = coords₁.ρ == coords₂.ρ && coords₁.ϕ == coords₂.ϕ
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Polar{Datum}}) where {Datum} =
-  Polar{Datum}(rand(rng), 2π * rand(rng))
+Random.rand(rng::Random.AbstractRNG, ::Type{Polar{Datum}}) where {Datum} = Polar{Datum}(rand(rng), 2π * rand(rng))
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Polar}) = rand(rng, Polar{NoDatum})
+Random.rand(rng::Random.AbstractRNG, ::Type{Polar}) = rand(rng, Polar{NoDatum})
 
 """
     Cylindrical(ρ, ϕ, z)
@@ -274,10 +273,10 @@ lentype(::Type{<:Cylindrical{Datum,L}}) where {Datum,L} = L
 ==(coords₁::Cylindrical{Datum}, coords₂::Cylindrical{Datum}) where {Datum} =
   coords₁.ρ == coords₂.ρ && coords₁.ϕ == coords₂.ϕ && coords₁.z == coords₂.z
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Cylindrical{Datum}}) where {Datum} =
+Random.rand(rng::Random.AbstractRNG, ::Type{Cylindrical{Datum}}) where {Datum} =
   Cylindrical{Datum}(rand(rng), 2π * rand(rng), rand(rng))
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Cylindrical}) = rand(rng, Cylindrical{NoDatum})
+Random.rand(rng::Random.AbstractRNG, ::Type{Cylindrical}) = rand(rng, Cylindrical{NoDatum})
 
 """
     Spherical(r, θ, ϕ)
@@ -329,10 +328,10 @@ lentype(::Type{<:Spherical{Datum,L}}) where {Datum,L} = L
 ==(coords₁::Spherical{Datum}, coords₂::Spherical{Datum}) where {Datum} =
   coords₁.r == coords₂.r && coords₁.θ == coords₂.θ && coords₁.ϕ == coords₂.ϕ
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Spherical{Datum}}) where {Datum} =
+Random.rand(rng::Random.AbstractRNG, ::Type{Spherical{Datum}}) where {Datum} =
   Spherical{Datum}(rand(rng), 2π * rand(rng), 2π * rand(rng))
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Spherical}) = rand(rng, Spherical{NoDatum})
+Random.rand(rng::Random.AbstractRNG, ::Type{Spherical}) = rand(rng, Spherical{NoDatum})
 
 # ------------
 # CONVERSIONS

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -59,10 +59,10 @@ lentype(::Type{<:GeodeticLatLon{Datum,D}}) where {Datum,D} = Met{numtype(D)}
 ==(coords₁::GeodeticLatLon{Datum}, coords₂::GeodeticLatLon{Datum}) where {Datum} =
   coords₁.lat == coords₂.lat && coords₁.lon == coords₂.lon
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeodeticLatLon{Datum}}) where {Datum} =
+Random.rand(rng::Random.AbstractRNG, ::Type{GeodeticLatLon{Datum}}) where {Datum} =
   GeodeticLatLon{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng))
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeodeticLatLon}) = rand(rng, GeodeticLatLon{WGS84Latest})
+Random.rand(rng::Random.AbstractRNG, ::Type{GeodeticLatLon}) = rand(rng, GeodeticLatLon{WGS84Latest})
 
 """
     LatLon(lat, lon)
@@ -138,11 +138,10 @@ lentype(::Type{<:GeodeticLatLonAlt{Datum,D,M}}) where {Datum,D,M} = M
 ==(coords₁::GeodeticLatLonAlt{Datum}, coords₂::GeodeticLatLonAlt{Datum}) where {Datum} =
   coords₁.lat == coords₂.lat && coords₁.lon == coords₂.lon && coords₁.alt == coords₂.alt
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeodeticLatLonAlt{Datum}}) where {Datum} =
+Random.rand(rng::Random.AbstractRNG, ::Type{GeodeticLatLonAlt{Datum}}) where {Datum} =
   GeodeticLatLonAlt{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng), rand(rng))
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeodeticLatLonAlt}) =
-  rand(rng, GeodeticLatLonAlt{WGS84Latest})
+Random.rand(rng::Random.AbstractRNG, ::Type{GeodeticLatLonAlt}) = rand(rng, GeodeticLatLonAlt{WGS84Latest})
 
 """
     LatLonAlt(lat, lon, alt)
@@ -211,10 +210,10 @@ lentype(::Type{<:GeocentricLatLon{Datum,D}}) where {Datum,D} = Met{numtype(D)}
 ==(coords₁::GeocentricLatLon{Datum}, coords₂::GeocentricLatLon{Datum}) where {Datum} =
   coords₁.lat == coords₂.lat && coords₁.lon == coords₂.lon
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeocentricLatLon{Datum}}) where {Datum} =
+Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLon{Datum}}) where {Datum} =
   GeocentricLatLon{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng))
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{GeocentricLatLon}) = rand(rng, GeocentricLatLon{WGS84Latest})
+Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLon}) = rand(rng, GeocentricLatLon{WGS84Latest})
 
 """
     AuthalicLatLon(lat, lon)
@@ -262,10 +261,10 @@ lentype(::Type{<:AuthalicLatLon{Datum,D}}) where {Datum,D} = Met{numtype(D)}
 ==(coords₁::AuthalicLatLon{Datum}, coords₂::AuthalicLatLon{Datum}) where {Datum} =
   coords₁.lat == coords₂.lat && coords₁.lon == coords₂.lon
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{AuthalicLatLon{Datum}}) where {Datum} =
+Random.rand(rng::Random.AbstractRNG, ::Type{AuthalicLatLon{Datum}}) where {Datum} =
   AuthalicLatLon{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng))
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{AuthalicLatLon}) = rand(rng, AuthalicLatLon{WGS84Latest})
+Random.rand(rng::Random.AbstractRNG, ::Type{AuthalicLatLon}) = rand(rng, AuthalicLatLon{WGS84Latest})
 
 # ------------
 # CONVERSIONS

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -39,7 +39,7 @@ Base.isapprox(coords₁::Projected{Datum}, coords₂::Projected{Datum}; kwargs..
 Base.isapprox(coords₁::Projected{Datum₁}, coords₂::Projected{Datum₂}; kwargs...) where {Datum₁,Datum₂} =
   isapprox(convert(Cartesian{Datum₁,3}, coords₁), convert(Cartesian{Datum₂,3}, coords₂); kwargs...)
 
-function Random.rand(rng::Random.AbstractRNG, C::Type{<:Projected})
+function Random.rand(rng::Random.AbstractRNG, ::Type{C}) where {C<:Projected}
   try
     convert(C, rand(rng, LatLon))
   catch

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -39,7 +39,7 @@ Base.isapprox(coords₁::Projected{Datum}, coords₂::Projected{Datum}; kwargs..
 Base.isapprox(coords₁::Projected{Datum₁}, coords₂::Projected{Datum₂}; kwargs...) where {Datum₁,Datum₂} =
   isapprox(convert(Cartesian{Datum₁,3}, coords₁), convert(Cartesian{Datum₂,3}, coords₂); kwargs...)
 
-function Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{C}) where {C<:Projected}
+function Random.rand(rng::Random.AbstractRNG, C::Type{<:Projected})
   try
     convert(C, rand(rng, LatLon))
   catch

--- a/test/crs/rand.jl
+++ b/test/crs/rand.jl
@@ -1,76 +1,70 @@
 @testset "Random CRS" begin
   @testset "Basic" begin
-    rng = StableRNG(123)
+    randtest(Cartesian{NoDatum,1})
+    randtest(Cartesian{NoDatum,2})
+    randtest(Cartesian{NoDatum,3})
+    randtest(Cartesian2D)
+    randtest(Cartesian3D)
 
-    @test rand(rng, Cartesian{NoDatum,1}) isa Cartesian
-    @test rand(rng, Cartesian{NoDatum,2}) isa Cartesian
-    @test rand(rng, Cartesian{NoDatum,3}) isa Cartesian
-    @test rand(rng, Cartesian2D) isa Cartesian
-    @test rand(rng, Cartesian3D) isa Cartesian
+    randtest(Polar{NoDatum})
+    randtest(Polar)
 
-    @test rand(rng, Polar{NoDatum}) isa Polar
-    @test rand(rng, Polar) isa Polar
+    randtest(Cylindrical{NoDatum})
+    randtest(Cylindrical)
 
-    @test rand(rng, Cylindrical{NoDatum}) isa Cylindrical
-    @test rand(rng, Cylindrical) isa Cylindrical
-
-    @test rand(rng, Spherical{NoDatum}) isa Spherical
-    @test rand(rng, Spherical) isa Spherical
+    randtest(Spherical{NoDatum})
+    randtest(Spherical)
   end
 
   @testset "Geographic" begin
-    rng = StableRNG(123)
+    randtest(GeodeticLatLon{WGS84Latest})
+    randtest(GeodeticLatLon)
 
-    @test rand(rng, GeodeticLatLon{WGS84Latest}) isa GeodeticLatLon
-    @test rand(rng, GeodeticLatLon) isa GeodeticLatLon{WGS84Latest}
+    randtest(LatLon{WGS84Latest})
+    randtest(LatLon)
 
-    @test rand(rng, LatLon{WGS84Latest}) isa LatLon
-    @test rand(rng, LatLon) isa LatLon{WGS84Latest}
+    randtest(GeodeticLatLonAlt{WGS84Latest})
+    randtest(GeodeticLatLonAlt)
 
-    @test rand(rng, GeodeticLatLonAlt{WGS84Latest}) isa GeodeticLatLonAlt
-    @test rand(rng, GeodeticLatLonAlt) isa GeodeticLatLonAlt{WGS84Latest}
+    randtest(LatLonAlt{WGS84Latest})
+    randtest(LatLonAlt)
 
-    @test rand(rng, LatLonAlt{WGS84Latest}) isa LatLonAlt
-    @test rand(rng, LatLonAlt) isa LatLonAlt{WGS84Latest}
+    randtest(GeocentricLatLon{WGS84Latest})
+    randtest(GeocentricLatLon)
 
-    @test rand(rng, GeocentricLatLon{WGS84Latest}) isa GeocentricLatLon
-    @test rand(rng, GeocentricLatLon) isa GeocentricLatLon{WGS84Latest}
-
-    @test rand(rng, AuthalicLatLon{WGS84Latest}) isa AuthalicLatLon
-    @test rand(rng, AuthalicLatLon) isa AuthalicLatLon{WGS84Latest}
+    randtest(AuthalicLatLon{WGS84Latest})
+    randtest(AuthalicLatLon)
   end
 
   @testset "Projected" begin
-    rng = StableRNG(123)
+    randtest(Mercator{WGS84Latest})
+    randtest(Mercator)
 
-    @test rand(rng, Mercator{WGS84Latest}) isa Mercator
-    @test rand(rng, Mercator) isa Mercator{WGS84Latest}
+    randtest(WebMercator{WGS84Latest})
+    randtest(WebMercator)
 
-    @test rand(rng, WebMercator{WGS84Latest}) isa WebMercator
-    @test rand(rng, WebMercator) isa WebMercator{WGS84Latest}
+    randtest(PlateCarree{WGS84Latest})
+    randtest(PlateCarree)
 
-    @test rand(rng, PlateCarree{WGS84Latest}) isa PlateCarree
-    @test rand(rng, PlateCarree) isa PlateCarree{WGS84Latest}
+    randtest(Lambert{WGS84Latest})
+    randtest(Lambert)
 
-    @test rand(rng, Lambert{WGS84Latest}) isa Lambert
-    @test rand(rng, Lambert) isa Lambert{WGS84Latest}
+    randtest(Behrmann{WGS84Latest})
+    randtest(Behrmann)
 
-    @test rand(rng, Behrmann{WGS84Latest}) isa Behrmann
-    @test rand(rng, Behrmann) isa Behrmann{WGS84Latest}
+    randtest(GallPeters{WGS84Latest})
+    randtest(GallPeters)
 
-    @test rand(rng, GallPeters{WGS84Latest}) isa GallPeters
-    @test rand(rng, GallPeters) isa GallPeters{WGS84Latest}
+    randtest(WinkelTripel{WGS84Latest})
+    randtest(WinkelTripel)
 
-    @test rand(rng, WinkelTripel{WGS84Latest}) isa WinkelTripel
-    @test rand(rng, WinkelTripel) isa WinkelTripel{WGS84Latest}
+    randtest(Robinson{WGS84Latest})
+    randtest(Robinson)
 
-    @test rand(rng, Robinson{WGS84Latest}) isa Robinson
-    @test rand(rng, Robinson) isa Robinson{WGS84Latest}
+    randtest(OrthoNorth{WGS84Latest})
+    randtest(OrthoNorth)
 
-    @test rand(rng, OrthoNorth{WGS84Latest}) isa OrthoNorth
-    @test rand(rng, OrthoNorth) isa OrthoNorth{WGS84Latest}
-
-    @test rand(rng, OrthoSouth{WGS84Latest}) isa OrthoSouth
-    @test rand(rng, OrthoSouth) isa OrthoSouth{WGS84Latest}
+    randtest(OrthoSouth{WGS84Latest})
+    randtest(OrthoSouth)
   end
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -74,6 +74,20 @@ function equaltest(CRS, n)
   @test c1 == c3
 end
 
+function randtest(CRS)
+  rng = StableRNG(123)
+
+  @test rand(CRS) isa CRS
+  @test rand(rng, CRS) isa CRS
+  @test eltype(rand(CRS, 10)) <: CRS
+  @test eltype(rand(rng, CRS, 10)) <: CRS
+
+  @inferred rand(CRS)
+  @inferred rand(rng, CRS)
+  @inferred rand(CRS, 10)
+  @inferred rand(rng, CRS, 10)
+end
+
 function wktstring(code; format="WKT2", multiline=false)
   spref = ArchGDAL.importUserInput(codestring(code))
   options = ["FORMAT=$format", "MULTILINE=$(multiline ? "YES" : "NO")"]


### PR DESCRIPTION
This PR implements the same `rand` design that was used in Meshes.jl:
```
rand(rng, CRS)
rand(rng, CRS, n)
rand(CRS)
rand(CRS, n)
```
Reference: https://github.com/JuliaGeometry/Meshes.jl/blob/master/src/rand.jl

Only methods with `n` were implemented, as methods with `dims` are not used at the moment.

# Benchmarks
```
julia> using CoordRefSystems

julia> using BenchmarkTools

julia> using Random; Random.seed!(123);
```
## main
```
julia> @benchmark rand(LatLon)
BenchmarkTools.Trial: 10000 samples with 997 evaluations.
 Range (min … max):  20.380 ns … 52.065 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     20.973 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   21.005 ns ±  1.625 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▇▅ ▃█▂                                                      ▂
  ██▁███▁▄▄▄▄▅▇▇▆▅▆▇▆▆▆▆▆▅▅▄▅▅▅▄▅▅▅▅▃▅▃▅▃▄▅▄▄▄▅▃▄▁▄▁▅▃▃▁▃▃▄▁▄ █
  20.4 ns      Histogram: log(frequency) by time      28.8 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark rand(LatLon{WGS84Latest})
BenchmarkTools.Trial: 10000 samples with 997 evaluations.
 Range (min … max):  20.383 ns … 56.931 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     20.998 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   20.974 ns ±  1.208 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

              █                                                
  ▃▆▇▃▂▂▁▁▁▂▃▆██▃▂▁▁▁▂▁▂▁▁▁▁▁▂▁▁▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▂
  20.4 ns         Histogram: frequency by time        23.3 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark rand(LatLon, 10000)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  244.660 μs …   5.591 ms  ┊ GC (min … max): 0.00% … 94.00%
 Time  (median):     248.367 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   268.606 μs ± 160.285 μs  ┊ GC (mean ± σ):  5.24% ±  7.85%

  █▆▆▅▃▂▂▂▂▁▁▁                    ▂                             ▂
  ████████████████▇▇▇▆██▆▇▆▆▆▇▆▄▅███▆▄▅▅▄▃▁▃▄▃▅▄▄▃▃▁▁▃▄▁▃▁▄▁▄▃▄ █
  245 μs        Histogram: log(frequency) by time        417 μs <

 Memory estimate: 390.67 KiB, allocs estimate: 10002.

julia> @benchmark rand(LatLon{WGS84Latest}, 10000)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  244.646 μs …   5.193 ms  ┊ GC (min … max): 0.00% … 94.26%
 Time  (median):     248.767 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   270.059 μs ± 161.676 μs  ┊ GC (mean ± σ):  5.27% ±  7.85%

  █▆▆▅▃▂▁▁▁▁▁▁▁▁          ▁▁                                    ▂
  ███████████████▇▇▇▇▇▆▆▇▇██▇▇▆▆▆▆▄▅▆▄▅▄▅▅▃▄▅▄▄▄▅▄▁▄▅▃▁▄▄▅▄▄▅▅▆ █
  245 μs        Histogram: log(frequency) by time        448 μs <

 Memory estimate: 390.67 KiB, allocs estimate: 10002.
```
## PR
```
julia> @benchmark rand(LatLon)
BenchmarkTools.Trial: 10000 samples with 997 evaluations.
 Range (min … max):  20.300 ns … 183.101 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     21.169 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   21.627 ns ±   2.796 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▁  █▇▂      ▁                                                
  ▂█▆▄███▇▃▃▆▅▄█▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▁▂▂▂▁▂▁▂▁▁▂▁▁▁▁▁▁▂▁▁▁▂ ▃
  20.3 ns         Histogram: frequency by time           30 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark rand(LatLon{WGS84Latest})
BenchmarkTools.Trial: 10000 samples with 997 evaluations.
 Range (min … max):  20.290 ns … 76.787 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     21.207 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   21.519 ns ±  1.760 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

             ▂▄█▃▂                  ▁   ▆                      
  ▁▁▁▃▅▇▂▃▃▃▂███████▇▂▂▆▁▁▂▁▁▂▂▂▁▂▄▄█▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  20.3 ns         Histogram: frequency by time        23.8 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark rand(LatLon, 10000)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  193.690 μs … 125.468 ms  ┊ GC (min … max): 0.00% … 99.78%
 Time  (median):     194.201 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   217.306 μs ±   1.256 ms  ┊ GC (mean ± σ):  6.60% ±  3.53%

  █▃▅▁                          ▅▂▄▂                            ▁
  █████▄▅▅▅▄▅▆▄▅▅▅▅▄▃▅▁▃▅▄▇▆▆▆▄██████▇▅▆▅▄▅▄▄▄▄▃▅▅▆▆▅▄▃▅▅▅▅▅▅▅▅ █
  194 μs        Histogram: log(frequency) by time        269 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.

julia> @benchmark rand(LatLon{WGS84Latest}, 10000)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  193.568 μs … 129.592 ms  ┊ GC (min … max): 0.00% … 99.78%
 Time  (median):     194.378 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   219.642 μs ±   1.298 ms  ┊ GC (mean ± σ):  6.84% ±  3.70%

  █▅▃▃                  ▄▃▃▁                                    ▁
  ██████▆▆▆▆▇▆▆▆▄▆▆▆▇▆▇█████▆▆▅▆▆▅▆▅▆▅▆▅▅▄▅▆▅▅▅▆▃▅▄▃▅▅▃▄▄▃▄▃▄▄▅ █
  194 μs        Histogram: log(frequency) by time        295 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.
```
## Without `checklon` and `fixlat`
Disabling checks in the `LatLon` constructor makes the code faster but less safe:
```julia
Random.rand(rng::Random.AbstractRNG, ::Type{GeodeticLatLon{Datum}}) where {Datum} =
  GeodeticLatLon{Datum,Deg{Float64}}(-90° + 180° * rand(rng), -180° + 360° * rand(rng))
```  
```
julia> @benchmark rand(LatLon)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  5.881 ns … 30.045 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.909 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.957 ns ±  0.773 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

      █▆█▄▅                                                   
  ▃▅▇▇██████▄▃▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▂▂▂▂▂▁▁▁▁▁▂▁▁▁▁▁▁▁▂▁▂ ▃
  5.88 ns        Histogram: frequency by time        6.14 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark rand(LatLon{WGS84Latest})
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  6.026 ns … 17.728 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     6.047 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.066 ns ±  0.250 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

          ▂▂ ▃▁▂ ▁▁▁ ▁▁ ▂▆▇ █▅▇ ▅▄ ▆▅▆ ▇▇ ▃▁           ▂ ▁    
  ▂▂▄▁▄▇█▁██▁███▁███▁██▁███▁███▁██▁███▁██▁██▇▁▇█▆▁▇▆▁▆▇█▁█▅▂ ▅
  6.03 ns        Histogram: frequency by time        6.07 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark rand(LatLon, 10000)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  44.705 μs …  3.338 ms  ┊ GC (min … max): 0.00% … 97.88%
 Time  (median):     46.278 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   54.639 μs ± 51.722 μs  ┊ GC (mean ± σ):  4.07% ±  4.93%

  ▆█▇▆▄▃▂▂                                      ▃▂▂▃▃▃▃▂▂▁▁   ▂
  ██████████▆▇▆▅▄▆▄▆▃▅▆▆▄▆▆▄▅▄▄▄▄▄▁▁▃▁▃▃▃▄▁▃▄▄▄▅████████████▇ █
  44.7 μs      Histogram: log(frequency) by time        88 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.

julia> @benchmark rand(LatLon{WGS84Latest}, 10000)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  44.571 μs …  2.884 ms  ┊ GC (min … max): 0.00% … 97.79%
 Time  (median):     45.752 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   53.369 μs ± 45.298 μs  ┊ GC (mean ± σ):  3.63% ±  4.89%

  ▅█▆▃▂▂▁▁                                         ▃▃▃▃▂▂▁    ▂
  ████████▇▇▆▅▆▆▅▆▆▅▅▅▅▆▆▅▅▅▄▅▁▄▁▁▃▃▁▁▄▁▃▄▃▃▁▄▄▅▄▄▄████████▇█ █
  44.6 μs      Histogram: log(frequency) by time      85.2 μs <

 Memory estimate: 156.30 KiB, allocs estimate: 2.
```
### Version info
```
Julia Version 1.10.4
Commit 48d4fd48430 (2024-06-04 10:41 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 12 × Intel(R) Core(TM) i5-10400 CPU @ 2.90GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-15.0.7 (ORCJIT, skylake)
Threads: 8 default, 0 interactive, 4 GC (on 12 virtual cores)
Environment:
  JULIA_EDITOR = code
  JULIA_NUM_THREADS = 8
```
