### PR TITLE
Add support for MAGNA-SIGRAS EPSG:4686

### DIFF
--- a/src/strings.jl
+++ b/src/strings.jl
@@ -86,5 +86,6 @@ const esriid2code = Dict(
   "World_Behrmann" => ESRI{54017},
   "World_Cylindrical_Equal_Area" => ESRI{54034},
   "World_Robinson" => ESRI{54030},
-  "World_Winkel_Tripel_NGS" => ESRI{54042}
+  "World_Winkel_Tripel_NGS" => ESRI{54042},
+  "GCS_MAGNA" => EPSG{4686}
 )

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -71,6 +71,7 @@ checkmatch(m) = isnothing(m) ? parseerror() : m
 # ESRI IDs in alphabetical order
 const esriid2code = Dict(
   "British_National_Grid" => EPSG{27700},
+  "GCS_MAGNA" => EPSG{4686},
   "GCS_SAD_1969_96" => EPSG{5527},
   "GCS_SIRGAS_2000" => EPSG{4674},
   "GCS_South_American_1969" => EPSG{4618},
@@ -86,6 +87,5 @@ const esriid2code = Dict(
   "World_Behrmann" => ESRI{54017},
   "World_Cylindrical_Equal_Area" => ESRI{54034},
   "World_Robinson" => ESRI{54030},
-  "World_Winkel_Tripel_NGS" => ESRI{54042},
-  "GCS_MAGNA" => EPSG{4686}
+  "World_Winkel_Tripel_NGS" => ESRI{54042}
 )

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -5,6 +5,7 @@
   crsstringtest(EPSG{4326})
   crsstringtest(EPSG{4618})
   crsstringtest(EPSG{4674})
+  crsstringtest(EPSG{4686})
   crsstringtest(EPSG{5527})
   crsstringtest(EPSG{32662})
   crsstringtest(EPSG{32633})


### PR DESCRIPTION
forward

@romu545 check this page: https://epsg.io/4686

At the bottom you can find the option "Export ESRI WKT". Click on it to see the following string:

GEOGCS["GCS_MAGNA",
    DATUM["D_MAGNA",
        SPHEROID["GRS_1980",6378137.0,298.257222101]],
    PRIMEM["Greenwich",0.0],
    UNIT["Degree",0.0174532925199433]]
