### PR TITLE
GeocentricLatLonAlt

### DIFF
--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -74,6 +74,7 @@ export
   GeodeticLatLon,
   GeodeticLatLonAlt,
   GeocentricLatLon,
+  GeocentricLatLonAlt,
   AuthalicLatLon,
   LatLon,
   LatLonAlt,

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -416,13 +416,13 @@ function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::GeocentricLatL
 end
 
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::LatLonAlt{Datum}) where {Datum}
-  geocentric = convert(GeocentricLatLon, LatLon{Datum}(coords.lat, coords.lon))
-  GeocentricLatLonAlt{Datum}(geocentric.lat, geocentric.lon, coords.alt)
+  lla = convert(GeocentricLatLon, LatLon{Datum}(coords.lat, coords.lon))
+  GeocentricLatLonAlt{Datum}(lla.lat, lla.lon, coords.alt)
 end
 
 function Base.convert(::Type{LatLonAlt{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum}
-  geodetic = convert(LatLon, GeocentricLatLon{Datum}(coords.lat, coords.lon))
-  LatLonAlt{Datum}(geodetic.lat, geodetic.lon, coords.alt)
+  lla = convert(LatLon, GeocentricLatLon{Datum}(coords.lat, coords.lon))
+  LatLonAlt{Datum}(lla.lat, lla.lon, coords.alt)
 end
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::LatLon{Datum}) where {Datum}

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -216,8 +216,8 @@ Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLon{Datum}}) where {Dat
 Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLon}) = rand(rng, GeocentricLatLon{WGS84Latest})
 
 """
-    GeoCentricLatLonAlt(lat, lon, alt)
-    GeoCentricLatLonAlt{Datum}(lat, lon, alt)
+    GeocentricLatLonAlt(lat, lon, alt)
+    GeocentricLatLonAlt{Datum}(lat, lon, alt)
 
 Geocentric latitude `lat ∈ [-90°,90°]` and longitude `lon ∈ [-180°,180°]` in angular units (default to degree)
 and altitude in length units (default to meter) with a given `Datum` (default to `WGS84Latest`).
@@ -440,6 +440,17 @@ function Base.convert(::Type{LatLon{Datum}}, coords::Cartesian{Datum,3}) where {
   lla = convert(LatLonAlt{Datum}, coords)
   convert(LatLon{Datum}, lla)
 end
+
+function Base.convert(::Type{Cartesian{Datum}}, coords::GeocentricLatLon{Datum}) where {Datum}
+  geocentric_lla = convert(GeocentricLatLonAlt{Datum}, coords);
+  return convert(Cartesian{Datum}, geocentric_lla)
+end
+
+function Base.convert(::Type{GeocentricLatLon{Datum}}, coords::Cartesian{Datum,3}) where {Datum}
+  geocentric_lla = convert(GeocentricLatLonAlt{Datum}, coords);
+  return convert(GeocentricLatLon{Datum}, geocentric_lla)
+end
+
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum}
   geodesic_coords = convert(LatLonAlt, coords);

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -513,6 +513,7 @@ function Base.convert(::Type{GeocentricLatLon{Datumₜ}}, coords::GeocentricLatL
   cartₜ = convert(Cartesian{Datumₜ}, cartₛ)
   convert(GeocentricLatLon{Datumₜ}, cartₜ)
 end
+
 # avoid converting coordinates with the same datum as the first argument
 Base.convert(::Type{GeocentricLatLon{Datum}}, coords::GeocentricLatLon{Datum}) where {Datum} = coords
 

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -263,8 +263,6 @@ Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLonAlt{Datum}}) where {
 
 Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLonAlt}) = rand(rng, GeocentricLatLonAlt{WGS84Latest})
 
-# ------------
-
 """
     AuthalicLatLon(lat, lon)
     AuthalicLatLon{Datum}(lat, lon)

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -415,7 +415,6 @@ function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::GeocentricLatL
   GeocentricLatLonAlt{Datum}(coords.lat, coords.lon, zero(T) * m)
 end
 
-# Cross conversion between LatLonAlt and GeocentricLatLonAlt
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::LatLonAlt{Datum}) where {Datum}
   geocentric = convert(GeocentricLatLon, LatLon{Datum}(coords.lat, coords.lon))
   GeocentricLatLonAlt{Datum}(geocentric.lat, geocentric.lon, coords.alt)
@@ -425,7 +424,6 @@ function Base.convert(::Type{LatLonAlt{Datum}}, coords::GeocentricLatLonAlt{Datu
   geodetic = convert(LatLon, GeocentricLatLon{Datum}(coords.lat, coords.lon))
   LatLonAlt{Datum}(geodetic.lat, geodetic.lon, coords.alt)
 end
-###################################################################
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::LatLon{Datum}) where {Datum}
   lla = convert(LatLonAlt{Datum}, coords)
@@ -448,13 +446,13 @@ function Base.convert(::Type{GeocentricLatLon{Datum}}, coords::Cartesian{Datum,3
 end
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum}
-  _coords = convert(LatLonAlt, coords)
-  convert(Cartesian{Datum}, _coords)
+  lla = convert(LatLonAlt, coords)
+  convert(Cartesian{Datum}, lla)
 end
 
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::Cartesian{Datum,3}) where {Datum}
-  _coords = convert(LatLonAlt, coords)
-  convert(GeocentricLatLonAlt{Datum}, _coords)
+  lla = convert(LatLonAlt, coords)
+  convert(GeocentricLatLonAlt{Datum}, lla)
 end
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::LatLonAlt{Datum}) where {Datum}

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -216,6 +216,56 @@ Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLon{Datum}}) where {Dat
 Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLon}) = rand(rng, GeocentricLatLon{WGS84Latest})
 
 """
+    GeoCentricLatLonAlt(lat, lon, alt)
+    GeoCentricLatLonAlt{Datum}(lat, lon, alt)
+
+Geocentric latitude `lat ∈ [-90°,90°]` and longitude `lon ∈ [-180°,180°]` in angular units (default to degree)
+and altitude in length units (default to meter) with a given `Datum` (default to `WGS84Latest`).
+"""
+struct GeocentricLatLonAlt{Datum,D<:Deg,M<:Met} <: Geographic{Datum}
+  lat::D
+  lon::D
+  alt::M
+end
+
+GeocentricLatLonAlt{Datum}(lat::D, lon::D, alt::M) where {Datum,D<:Deg,M<:Met} =
+  GeocentricLatLonAlt{Datum,float(D),float(M)}(checklat(lat), fixlon(lon), alt)
+GeocentricLatLonAlt{Datum}(lat::Deg, lon::Deg, alt::Met) where {Datum} =
+    GeocentricLatLonAlt{Datum}(promote(lat, lon)..., alt)
+GeocentricLatLonAlt{Datum}(lat::Deg, lon::Deg, alt::Len) where {Datum} =
+    GeocentricLatLonAlt{Datum}(lat, lon, uconvert(m, alt))
+GeocentricLatLonAlt{Datum}(lat::Rad, lon::Rad, alt::Len) where {Datum} =
+    GeocentricLatLonAlt{Datum}(rad2deg(lat), rad2deg(lon), alt)
+GeocentricLatLonAlt{Datum}(lat::Number, lon::Number, alt::Number) where {Datum} =
+    GeocentricLatLonAlt{Datum}(addunit(lat, °), addunit(lon, °), addunit(alt, m))
+
+GeocentricLatLonAlt(args...) = GeocentricLatLonAlt{WGS84Latest}(args...)
+
+Base.convert(::Type{GeocentricLatLonAlt{Datum,D,M}}, coords::GeocentricLatLonAlt{Datum}) where {Datum,D,M} =
+    GeocentricLatLonAlt{Datum,D,M}(coords.lat, coords.lon, coords.alt)
+
+raw(coords::GeocentricLatLonAlt) = ustrip(coords.lon), ustrip(coords.lat), ustrip(coords.alt) # reverse order
+
+constructor(::Type{<:GeocentricLatLonAlt{Datum}}) where {Datum} = GeocentricLatLonAlt{Datum}
+
+function reconstruct(C::Type{<:GeocentricLatLonAlt}, raw)
+    lon, lat, alt = raw .* units(C)
+    constructor(C)(lat, lon, alt) # reverse order
+end
+
+lentype(::Type{<:GeocentricLatLonAlt{Datum,D,M}}) where {Datum,D,M} = M
+
+==(coords₁::GeocentricLatLonAlt{Datum}, coords₂::GeocentricLatLonAlt{Datum}) where {Datum} =
+    coords₁.lat == coords₂.lat && coords₁.lon == coords₂.lon && coords₁.alt == coords₂.alt
+
+Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLonAlt{Datum}}) where {Datum} =
+    GeocentricLatLonAlt{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng), rand(rng))
+
+Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLonAlt}) = rand(rng, GeocentricLatLonAlt{WGS84Latest})
+
+# ------------
+
+"""
     AuthalicLatLon(lat, lon)
     AuthalicLatLon{Datum}(lat, lon)
 

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -535,6 +535,6 @@ Base.convert(::Type{LatLonAlt}, coords::CRS{Datum}) where {Datum} = convert(LatL
 
 Base.convert(::Type{GeocentricLatLon}, coords::CRS{Datum}) where {Datum} = convert(GeocentricLatLon{Datum}, coords)
 
-Base.convert(::Type{GeocentricLatLonAlt}, coords::CRS{Datum}) where {Datum} = convert(GeocentricLatLonAlts{Datum}, coords)
+Base.convert(::Type{GeocentricLatLonAlt}, coords::CRS{Datum}) where {Datum} = convert(GeocentricLatLonAlt{Datum}, coords)
 
 Base.convert(::Type{AuthalicLatLon}, coords::CRS{Datum}) where {Datum} = convert(AuthalicLatLon{Datum}, coords)

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -231,35 +231,35 @@ end
 GeocentricLatLonAlt{Datum}(lat::D, lon::D, alt::M) where {Datum,D<:Deg,M<:Met} =
   GeocentricLatLonAlt{Datum,float(D),float(M)}(checklat(lat), fixlon(lon), alt)
 GeocentricLatLonAlt{Datum}(lat::Deg, lon::Deg, alt::Met) where {Datum} =
-    GeocentricLatLonAlt{Datum}(promote(lat, lon)..., alt)
+  GeocentricLatLonAlt{Datum}(promote(lat, lon)..., alt)
 GeocentricLatLonAlt{Datum}(lat::Deg, lon::Deg, alt::Len) where {Datum} =
-    GeocentricLatLonAlt{Datum}(lat, lon, uconvert(m, alt))
+  GeocentricLatLonAlt{Datum}(lat, lon, uconvert(m, alt))
 GeocentricLatLonAlt{Datum}(lat::Rad, lon::Rad, alt::Len) where {Datum} =
-    GeocentricLatLonAlt{Datum}(rad2deg(lat), rad2deg(lon), alt)
+  GeocentricLatLonAlt{Datum}(rad2deg(lat), rad2deg(lon), alt)
 GeocentricLatLonAlt{Datum}(lat::Number, lon::Number, alt::Number) where {Datum} =
-    GeocentricLatLonAlt{Datum}(addunit(lat, °), addunit(lon, °), addunit(alt, m))
+  GeocentricLatLonAlt{Datum}(addunit(lat, °), addunit(lon, °), addunit(alt, m))
 
 GeocentricLatLonAlt(args...) = GeocentricLatLonAlt{WGS84Latest}(args...)
 
 Base.convert(::Type{GeocentricLatLonAlt{Datum,D,M}}, coords::GeocentricLatLonAlt{Datum}) where {Datum,D,M} =
-    GeocentricLatLonAlt{Datum,D,M}(coords.lat, coords.lon, coords.alt)
+  GeocentricLatLonAlt{Datum,D,M}(coords.lat, coords.lon, coords.alt)
 
 raw(coords::GeocentricLatLonAlt) = ustrip(coords.lon), ustrip(coords.lat), ustrip(coords.alt) # reverse order
 
 constructor(::Type{<:GeocentricLatLonAlt{Datum}}) where {Datum} = GeocentricLatLonAlt{Datum}
 
 function reconstruct(C::Type{<:GeocentricLatLonAlt}, raw)
-    lon, lat, alt = raw .* units(C)
-    constructor(C)(lat, lon, alt) # reverse order
+  lon, lat, alt = raw .* units(C)
+  constructor(C)(lat, lon, alt) # reverse order
 end
 
 lentype(::Type{<:GeocentricLatLonAlt{Datum,D,M}}) where {Datum,D,M} = M
 
 ==(coords₁::GeocentricLatLonAlt{Datum}, coords₂::GeocentricLatLonAlt{Datum}) where {Datum} =
-    coords₁.lat == coords₂.lat && coords₁.lon == coords₂.lon && coords₁.alt == coords₂.alt
+  coords₁.lat == coords₂.lat && coords₁.lon == coords₂.lon && coords₁.alt == coords₂.alt
 
 Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLonAlt{Datum}}) where {Datum} =
-    GeocentricLatLonAlt{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng), rand(rng))
+  GeocentricLatLonAlt{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng), rand(rng))
 
 Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLonAlt}) = rand(rng, GeocentricLatLonAlt{WGS84Latest})
 
@@ -410,7 +410,8 @@ function Base.convert(::Type{LatLonAlt{Datum}}, coords::LatLon{Datum}) where {Da
 end
 
 # Conversion from GeocentriLatLonAlt to GeocentriLatLonAlt
-Base.convert(::Type{GeocentricLatLon{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum} = GeocentricLatLon{Datum}(coords.lat, coords.lon)
+Base.convert(::Type{GeocentricLatLon{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum} =
+  GeocentricLatLon{Datum}(coords.lat, coords.lon)
 
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::GeocentricLatLon{Datum}) where {Datum}
   T = numtype(coords.lon)
@@ -419,17 +420,15 @@ end
 
 # Cross conversion between LatLonAlt and GeocentricLatLonAlt
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::LatLonAlt{Datum}) where {Datum}
-  geocentric = convert(GeocentricLatLon, LatLon{Datum}(coords.lat, coords.lon));
-  return GeocentricLatLonAlt{Datum}(geocentric.lat, geocentric.lon, coords.alt);
+  geocentric = convert(GeocentricLatLon, LatLon{Datum}(coords.lat, coords.lon))
+  GeocentricLatLonAlt{Datum}(geocentric.lat, geocentric.lon, coords.alt)
 end
 
 function Base.convert(::Type{LatLonAlt{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum}
-  geodetic  = convert(LatLon, GeocentricLatLon{Datum}(coords.lat, coords.lon));
-  return LatLonAlt{Datum}(geodetic.lat, geodetic.lon, coords.alt);
+  geodetic = convert(LatLon, GeocentricLatLon{Datum}(coords.lat, coords.lon))
+  LatLonAlt{Datum}(geodetic.lat, geodetic.lon, coords.alt)
 end
 ###################################################################
-
-
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::LatLon{Datum}) where {Datum}
   lla = convert(LatLonAlt{Datum}, coords)
@@ -442,26 +441,24 @@ function Base.convert(::Type{LatLon{Datum}}, coords::Cartesian{Datum,3}) where {
 end
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::GeocentricLatLon{Datum}) where {Datum}
-  geocentric_lla = convert(GeocentricLatLonAlt{Datum}, coords);
-  return convert(Cartesian{Datum}, geocentric_lla)
+  lla = convert(GeocentricLatLonAlt{Datum}, coords)
+  convert(Cartesian{Datum}, lla)
 end
 
 function Base.convert(::Type{GeocentricLatLon{Datum}}, coords::Cartesian{Datum,3}) where {Datum}
-  geocentric_lla = convert(GeocentricLatLonAlt{Datum}, coords);
-  return convert(GeocentricLatLon{Datum}, geocentric_lla)
+  lla = convert(GeocentricLatLonAlt{Datum}, coords)
+  convert(GeocentricLatLon{Datum}, lla)
 end
 
-
 function Base.convert(::Type{Cartesian{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum}
-  geodesic_coords = convert(LatLonAlt, coords);
-  return convert(Cartesian{Datum}, geodesic_coords)
+  _coords = convert(LatLonAlt, coords)
+  convert(Cartesian{Datum}, _coords)
 end
 
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::Cartesian{Datum,3}) where {Datum}
-  geodesic_coords = convert(LatLonAlt, coords);
-  return convert(GeocentricLatLonAlt{Datum}, geodesic_coords)
+  _coords = convert(LatLonAlt, coords)
+  convert(GeocentricLatLonAlt{Datum}, _coords)
 end
-
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::LatLonAlt{Datum}) where {Datum}
   T = numtype(coords.lon)
@@ -516,10 +513,9 @@ end
 # avoid converting coordinates with the same datum as the first argument
 Base.convert(::Type{LatLon{Datum}}, coords::LatLon{Datum}) where {Datum} = coords
 
-
 function Base.convert(::Type{GeocentricLatLon{Datumₜ}}, coords::GeocentricLatLon{Datumₛ}) where {Datumₜ,Datumₛ}
-  cartₛ = convert(Cartesian{Datumₛ}, coords);
-  cartₜ = convert(Cartesian{Datumₜ}, cartₛ);
+  cartₛ = convert(Cartesian{Datumₛ}, coords)
+  cartₜ = convert(Cartesian{Datumₜ}, cartₛ)
   convert(GeocentricLatLon{Datumₜ}, cartₜ)
 end
 # avoid converting coordinates with the same datum as the first argument
@@ -535,6 +531,7 @@ Base.convert(::Type{LatLonAlt}, coords::CRS{Datum}) where {Datum} = convert(LatL
 
 Base.convert(::Type{GeocentricLatLon}, coords::CRS{Datum}) where {Datum} = convert(GeocentricLatLon{Datum}, coords)
 
-Base.convert(::Type{GeocentricLatLonAlt}, coords::CRS{Datum}) where {Datum} = convert(GeocentricLatLonAlt{Datum}, coords)
+Base.convert(::Type{GeocentricLatLonAlt}, coords::CRS{Datum}) where {Datum} =
+  convert(GeocentricLatLonAlt{Datum}, coords)
 
 Base.convert(::Type{AuthalicLatLon}, coords::CRS{Datum}) where {Datum} = convert(AuthalicLatLon{Datum}, coords)

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -407,7 +407,6 @@ function Base.convert(::Type{LatLonAlt{Datum}}, coords::LatLon{Datum}) where {Da
   LatLonAlt{Datum}(coords.lat, coords.lon, zero(T) * m)
 end
 
-# Conversion from GeocentriLatLonAlt to GeocentriLatLonAlt
 Base.convert(::Type{GeocentricLatLon{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum} =
   GeocentricLatLon{Datum}(coords.lat, coords.lon)
 

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -115,32 +115,29 @@ include("projected/transversemercator.jl")
 # ----------
 # FALLBACKS
 # ----------
-function Base.convert(::Type{C},coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}}
-  return convert(C, convert(LatLon{Datum}, coords))
+function Base.convert(::Type{C}, coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}}
+  convert(C, convert(LatLon{Datum}, coords))
 end
 
 function Base.convert(::Type{GeocentricLatLon{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
-  return convert(GeocentricLatLon{Datum}, convert(LatLon{Datum}, coords))
+  convert(GeocentricLatLon{Datum}, convert(LatLon{Datum}, coords))
 end
 
 function Base.convert(::Type{C}, coords::GeocentricLatLonAlt{Datum}) where {Datum,C<:Projected{Datum}}
-  return convert(C, convert(GeocentricLatLon{Datum}, coords))
+  convert(C, convert(GeocentricLatLon{Datum}, coords))
 end
 
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
-  return convert(GeocentricLatLonAlt{Datum}, convert(GeocentricLatLon{Datum}, coords))
+  convert(GeocentricLatLonAlt{Datum}, convert(GeocentricLatLon{Datum}, coords))
 end
 
 function Base.convert(::Type{C}, coords::LatLonAlt{Datum}) where {Datum,C<:Projected{Datum}}
-  return convert(C, convert(LatLon{Datum}, coords))
+  convert(C, convert(LatLon{Datum}, coords))
 end
 
 function Base.convert(::Type{LatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
-  return convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
+  convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
 end
-
-
-
 
 function Base.convert(::Type{C}, coords::LatLon{Datum}) where {Datum,C<:Projected{Datum}}
   S = projshift(C)

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -115,6 +115,32 @@ include("projected/transversemercator.jl")
 # ----------
 # FALLBACKS
 # ----------
+function Base.convert(::Type{C},coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}}
+  return convert(C, convert(LatLon{Datum}, coords))
+end
+
+function Base.convert(::Type{GeocentricLatLon{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
+  return convert(GeocentricLatLon{Datum}, convert(LatLon{Datum}, coords))
+end
+
+function Base.convert(::Type{C}, coords::GeocentricLatLonAlt{Datum}) where {Datum,C<:Projected{Datum}}
+  return convert(C, convert(GeocentricLatLon{Datum}, coords))
+end
+
+function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
+  return convert(GeocentricLatLonAlt{Datum}, convert(GeocentricLatLon{Datum}, coords))
+end
+
+function Base.convert(::Type{C}, coords::LatLonAlt{Datum}) where {Datum,C<:Projected{Datum}}
+  return convert(C, convert(LatLon{Datum}, coords))
+end
+
+function Base.convert(::Type{LatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
+  return convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
+end
+
+
+
 
 function Base.convert(::Type{C}, coords::LatLon{Datum}) where {Datum,C<:Projected{Datum}}
   S = projshift(C)

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -115,6 +115,7 @@ include("projected/transversemercator.jl")
 # ----------
 # FALLBACKS
 # ----------
+
 function Base.convert(::Type{C}, coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}}
   convert(C, convert(LatLon{Datum}, coords))
 end

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -128,7 +128,6 @@ Base.convert(::Type{C}, coords::LatLonAlt{Datum}) where {Datum,C<:Projected{Datu
 
 Base.convert(::Type{LatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} = convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
 
-
 function Base.convert(::Type{C}, coords::LatLon{Datum}) where {Datum,C<:Projected{Datum}}
   S = projshift(C)
   T = numtype(coords.lon)

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -116,29 +116,18 @@ include("projected/transversemercator.jl")
 # FALLBACKS
 # ----------
 
-function Base.convert(::Type{C}, coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}}
-  convert(C, convert(LatLon{Datum}, coords))
-end
+Base.convert(::Type{C}, coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}} = convert(C, convert(LatLon{Datum}, coords))
 
-function Base.convert(::Type{GeocentricLatLon{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
-  convert(GeocentricLatLon{Datum}, convert(LatLon{Datum}, coords))
-end
+Base.convert(::Type{GeocentricLatLon{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} = convert(GeocentricLatLon{Datum}, convert(LatLon{Datum}, coords))
 
-function Base.convert(::Type{C}, coords::GeocentricLatLonAlt{Datum}) where {Datum,C<:Projected{Datum}}
-  convert(C, convert(GeocentricLatLon{Datum}, coords))
-end
+Base.convert(::Type{C}, coords::GeocentricLatLonAlt{Datum}) where {Datum,C<:Projected{Datum}} = convert(C, convert(GeocentricLatLon{Datum}, coords))
 
-function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
-  convert(GeocentricLatLonAlt{Datum}, convert(GeocentricLatLon{Datum}, coords))
-end
+Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} = convert(GeocentricLatLonAlt{Datum}, convert(GeocentricLatLon{Datum}, coords))
 
-function Base.convert(::Type{C}, coords::LatLonAlt{Datum}) where {Datum,C<:Projected{Datum}}
-  convert(C, convert(LatLon{Datum}, coords))
-end
+Base.convert(::Type{C}, coords::LatLonAlt{Datum}) where {Datum,C<:Projected{Datum}} = convert(C, convert(LatLon{Datum}, coords))
 
-function Base.convert(::Type{LatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
-  convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
-end
+Base.convert(::Type{LatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} = convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
+
 
 function Base.convert(::Type{C}, coords::LatLon{Datum}) where {Datum,C<:Projected{Datum}}
   S = projshift(C)

--- a/test/crs/constructors.jl
+++ b/test/crs/constructors.jl
@@ -262,7 +262,6 @@
       @test_throws ArgumentError GeocentricLatLon(T(1) * °, T(1) * s)
       @test_throws ArgumentError GeocentricLatLon(T(1) * s, T(1) * s)
     end
-    # Add Test for GeocentricLatLonAlt
     @testset "GeocentricLatLonAlt" begin
       @test GeocentricLatLonAlt(T(1), T(2), T(3)) == GeocentricLatLonAlt(T(1) * °, T(2) * °, T(3) * m)
       @test GeocentricLatLonAlt(T(1) * °, 2 * °, T(3) * m) == GeocentricLatLonAlt(T(1) * °, T(2) * °, T(3) * m)

--- a/test/crs/constructors.jl
+++ b/test/crs/constructors.jl
@@ -262,6 +262,7 @@
       @test_throws ArgumentError GeocentricLatLon(T(1) * °, T(1) * s)
       @test_throws ArgumentError GeocentricLatLon(T(1) * s, T(1) * s)
     end
+
     @testset "GeocentricLatLonAlt" begin
       @test GeocentricLatLonAlt(T(1), T(2), T(3)) == GeocentricLatLonAlt(T(1) * °, T(2) * °, T(3) * m)
       @test GeocentricLatLonAlt(T(1) * °, 2 * °, T(3) * m) == GeocentricLatLonAlt(T(1) * °, T(2) * °, T(3) * m)

--- a/test/crs/constructors.jl
+++ b/test/crs/constructors.jl
@@ -264,7 +264,6 @@
     end
     # Add Test for GeocentricLatLonAlt
     @testset "GeocentricLatLonAlt" begin
-
     end
 
     @testset "AuthalicLatLon" begin

--- a/test/crs/constructors.jl
+++ b/test/crs/constructors.jl
@@ -262,6 +262,10 @@
       @test_throws ArgumentError GeocentricLatLon(T(1) * °, T(1) * s)
       @test_throws ArgumentError GeocentricLatLon(T(1) * s, T(1) * s)
     end
+    # Add Test for GeocentricLatLonAlt
+    @testset "GeocentricLatLonAlt" begin
+
+    end
 
     @testset "AuthalicLatLon" begin
       @test AuthalicLatLon(T(1), T(2)) == AuthalicLatLon(T(1) * °, T(2) * °)

--- a/test/crs/constructors.jl
+++ b/test/crs/constructors.jl
@@ -264,6 +264,34 @@
     end
     # Add Test for GeocentricLatLonAlt
     @testset "GeocentricLatLonAlt" begin
+      @test GeocentricLatLonAlt(T(1), T(2), T(3)) == GeocentricLatLonAlt(T(1) * °, T(2) * °, T(3) * m)
+      @test GeocentricLatLonAlt(T(1) * °, 2 * °, T(3) * m) == GeocentricLatLonAlt(T(1) * °, T(2) * °, T(3) * m)
+      @test allapprox(
+        GeocentricLatLonAlt(T(π / 4) * rad, T(π / 4) * rad, T(1) * km),
+        GeocentricLatLonAlt(T(45) * °, T(45) * °, T(1000) * m)
+      )
+
+      c = GeocentricLatLonAlt(T(1), T(2), T(3))
+      @test sprint(show, c) == "GeocentricLatLonAlt{WGS84Latest}(lat: 1.0°, lon: 2.0°, alt: 3.0 m)"
+      if T === Float32
+        @test sprint(show, MIME("text/plain"), c) == """
+        GeocentricLatLonAlt{WGS84Latest} coordinates
+        ├─ lat: 1.0f0°
+        ├─ lon: 2.0f0°
+        └─ alt: 3.0f0 m"""
+      else
+        @test sprint(show, MIME("text/plain"), c) == """
+        GeocentricLatLonAlt{WGS84Latest} coordinates
+        ├─ lat: 1.0°
+        ├─ lon: 2.0°
+        └─ alt: 3.0 m"""
+      end
+
+      # error: invalid units for coordinates
+      @test_throws ArgumentError GeocentricLatLonAlt(T(1), T(1) * °, T(1) * m)
+      @test_throws ArgumentError GeocentricLatLonAlt(T(1) * s, T(1) * °, T(1) * m)
+      @test_throws ArgumentError GeocentricLatLonAlt(T(1) * °, T(1) * s, T(1) * m)
+      @test_throws ArgumentError GeocentricLatLonAlt(T(1) * °, T(1) * °, T(1) * s)
     end
 
     @testset "AuthalicLatLon" begin

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -352,9 +352,7 @@
 
     # conversion LatLonAlt <> GeocentricLatLonAlt is tested in the next section
     @testset "LatLonAlt <> GeocentricLatLonAlt" begin
-
     end
-
 
     if T === Float64
       # altitude can only be calculated accurately using Float64
@@ -407,7 +405,6 @@
 
       # conversion GeocentricLatLonAlt <> Cartesian is tested in the next section
       @testset "GeocentricLatLonAlt <> Cartesian" begin
-
       end
     end
 

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -352,6 +352,17 @@
 
     # conversion LatLonAlt <> GeocentricLatLonAlt is tested in the next section
     @testset "LatLonAlt <> GeocentricLatLonAlt" begin
+      c1 = LatLonAlt(T(30), T(40), T(0))
+      c2 = convert(GeocentricLatLonAlt, c1)
+      @test allapprox(c2, GeocentricLatLonAlt(T(29.833635809829065), T(40), T(0)))
+      c3 = convert(LatLonAlt, c2)
+      @test allapprox(c3, c1)
+
+      # type stability
+      c1 = LatLonAlt(T(30), T(40), T(0))
+      c2 = GeocentricLatLonAlt(T(29.833635809829065), T(40), T(0))
+      @inferred convert(GeocentricLatLonAlt, c1)
+      @inferred convert(LatLonAlt, c2)
     end
 
     if T === Float64
@@ -405,6 +416,47 @@
 
       # conversion GeocentricLatLonAlt <> Cartesian is tested in the next section
       @testset "GeocentricLatLonAlt <> Cartesian" begin
+        c1 = GeocentricLatLonAlt(T(30), T(40), T(0))
+        c2 = convert(Cartesian, c1)
+        @test allapprox(c2, Cartesian{WGS84Latest}(T(4227784.905275363), T(3547532.754713428), T(3186385.300568595)))
+        c3 = convert(GeocentricLatLonAlt, c2)
+        @test allapprox(c3, c1)
+
+        c1 = GeocentricLatLonAlt(T(35), T(45), T(100))
+        c2 = convert(Cartesian, c1)
+        @test allapprox(c2, Cartesian{WGS84Latest}(T(3690364.254026674), T(3690364.2540266733), T(3654357.744678035)))
+        c3 = convert(GeocentricLatLonAlt, c2)
+        @test allapprox(c3, c1)
+
+        c1 = GeocentricLatLonAlt(T(40), T(50), T(200))
+        c2 = convert(Cartesian, c1)
+        @test allapprox(c2, Cartesian{WGS84Latest}(T(3136354.020667129), T(3737761.1717773457), T(4094220.2645078264)))
+        c3 = convert(GeocentricLatLonAlt, c2)
+        @test allapprox(c3, c1)
+
+        c1 = GeocentricLatLonAlt(-T(30), -T(40), T(0))
+        c2 = convert(Cartesian, c1)
+        @test allapprox(c2, Cartesian{WGS84Latest}(T(4227784.905275363), -T(3547532.754713428), -T(3186385.300568595)))
+        c3 = convert(GeocentricLatLonAlt, c2)
+        @test allapprox(c3, c1)
+
+        c1 = GeocentricLatLonAlt(-T(35), T(45), T(100))
+        c2 = convert(Cartesian, c1)
+        @test allapprox(c2, Cartesian{WGS84Latest}(T(3690364.254026674), T(3690364.2540266733), -T(3654357.744678035)))
+        c3 = convert(GeocentricLatLonAlt, c2)
+        @test allapprox(c3, c1)
+
+        c1 = GeocentricLatLonAlt(T(40), -T(50), T(200))
+        c2 = convert(Cartesian, c1)
+        @test allapprox(c2,Cartesian{WGS84Latest}(T(3136354.020667129), -T(3737761.1717773457), T(4094220.2645078264)))
+        c3 = convert(GeocentricLatLonAlt, c2)
+        @test allapprox(c3, c1)
+
+        # type stability
+        c1 = GeocentricLatLonAlt(T(30), T(40), T(0))
+        c2 = Cartesian{WGS84Latest}(T(4227784.905275363), T(3547532.754713428), T(3186385.300568595))
+        @inferred convert(Cartesian, c1)
+        @inferred convert(LatLonAlt, c2)
       end
     end
 

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -204,7 +204,7 @@
   end
 
   @testset "Geographic" begin
-    @testset "GeodeticLatLon <> GeocentricLatLon" begin
+    @testset "LatLon <> GeocentricLatLon" begin
       c1 = LatLon(T(30), T(40))
       c2 = convert(GeocentricLatLon, c1)
       @test allapprox(c2, GeocentricLatLon(T(29.833635809829065), T(40)))
@@ -248,7 +248,7 @@
       @inferred convert(LatLon, c2)
     end
 
-    @testset "GeodeticLatLon <> AuthalicLatLon" begin
+    @testset "LatLon <> AuthalicLatLon" begin
       c1 = LatLon(T(30), T(40))
       c2 = convert(AuthalicLatLon, c1)
       @test allapprox(c2, AuthalicLatLon(T(29.888997034459567), T(40)))
@@ -290,6 +290,34 @@
       c2 = AuthalicLatLon(T(29.888997034459567), T(40))
       @inferred convert(AuthalicLatLon, c1)
       @inferred convert(LatLon, c2)
+    end
+
+    @testset "LatLon <> LatLonAlt" begin
+      c1 = LatLon(T(30), T(40))
+      c2 = convert(LatLonAlt, c1)
+      @test allapprox(c2, LatLonAlt(T(30), T(40), T(0)))
+      c3 = convert(LatLon, c2)
+      @test allapprox(c3, c1)
+
+      # type stability
+      c1 = LatLon(T(30), T(40))
+      c2 = LatLonAlt(T(30), T(40), T(0))
+      @inferred convert(LatLonAlt, c1)
+      @inferred convert(LatLon, c2)
+    end
+
+    @testset "LatLonAlt <> GeocentricLatLonAlt" begin
+      c1 = LatLonAlt(T(30), T(40), T(0))
+      c2 = convert(GeocentricLatLonAlt, c1)
+      @test allapprox(c2, GeocentricLatLonAlt(T(29.833635809829065), T(40), T(0)))
+      c3 = convert(LatLonAlt, c2)
+      @test allapprox(c3, c1)
+
+      # type stability
+      c1 = LatLonAlt(T(30), T(40), T(0))
+      c2 = GeocentricLatLonAlt(T(29.833635809829065), T(40), T(0))
+      @inferred convert(GeocentricLatLonAlt, c1)
+      @inferred convert(LatLonAlt, c2)
     end
 
     @testset "LatLon <> Cartesian" begin
@@ -334,34 +362,6 @@
       c2 = Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
       @inferred convert(Cartesian, c1)
       @inferred convert(LatLon, c2)
-    end
-
-    @testset "LatLon <> LatLonAlt" begin
-      c1 = LatLon(T(30), T(40))
-      c2 = convert(LatLonAlt, c1)
-      @test allapprox(c2, LatLonAlt(T(30), T(40), T(0)))
-      c3 = convert(LatLon, c2)
-      @test allapprox(c3, c1)
-
-      # type stability
-      c1 = LatLon(T(30), T(40))
-      c2 = LatLonAlt(T(30), T(40), T(0))
-      @inferred convert(LatLonAlt, c1)
-      @inferred convert(LatLon, c2)
-    end
-
-    @testset "LatLonAlt <> GeocentricLatLonAlt" begin
-      c1 = LatLonAlt(T(30), T(40), T(0))
-      c2 = convert(GeocentricLatLonAlt, c1)
-      @test allapprox(c2, GeocentricLatLonAlt(T(29.833635809829065), T(40), T(0)))
-      c3 = convert(LatLonAlt, c2)
-      @test allapprox(c3, c1)
-
-      # type stability
-      c1 = LatLonAlt(T(30), T(40), T(0))
-      c2 = GeocentricLatLonAlt(T(29.833635809829065), T(40), T(0))
-      @inferred convert(GeocentricLatLonAlt, c1)
-      @inferred convert(LatLonAlt, c2)
     end
 
     if T === Float64
@@ -864,6 +864,18 @@
       @inferred convert(LatLon{ITRF{2008}}, c3)
       @inferred convert(LatLon{WGS84{2296}}, c4)
       @inferred convert(LatLon{WGS84{0}}, c5)
+    end
+
+    @testset "LatLonAlt: Datum conversion" begin
+      # TODO
+    end
+
+    @testset "GeocentricLatLon: Datum conversion" begin
+      # TODO
+    end
+
+    @testset "GeocentricLatLonAlt: Datum conversion" begin
+      # TODO
     end
   end
 
@@ -1452,7 +1464,7 @@
       @inferred convert(Cartesian3D, c6)
     end
 
-    @testset "Projection conversion" begin
+    @testset "Projected <> Projected" begin
       ShiftedMercator = CoordRefSystems.shift(Mercator{WGS84Latest}, lonₒ=15.0°, xₒ=200.0m, yₒ=200.0m)
 
       # same datum

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -350,7 +350,6 @@
       @inferred convert(LatLon, c2)
     end
 
-    # conversion LatLonAlt <> GeocentricLatLonAlt is tested in the next section
     @testset "LatLonAlt <> GeocentricLatLonAlt" begin
       c1 = LatLonAlt(T(30), T(40), T(0))
       c2 = convert(GeocentricLatLonAlt, c1)
@@ -414,7 +413,6 @@
         @inferred convert(LatLonAlt, c2)
       end
 
-      # conversion GeocentricLatLonAlt <> Cartesian is tested in the next section
       @testset "GeocentricLatLonAlt <> Cartesian" begin
         c1 = GeocentricLatLonAlt(T(30), T(40), T(0))
         c2 = convert(Cartesian, c1)

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -350,6 +350,12 @@
       @inferred convert(LatLon, c2)
     end
 
+    # conversion LatLonAlt <> GeocentricLatLonAlt is tested in the next section
+    @testset "LatLonAlt <> GeocentricLatLonAlt" begin
+
+    end
+
+
     if T === Float64
       # altitude can only be calculated accurately using Float64
       @testset "LatLonAlt <> Cartesian" begin
@@ -397,6 +403,11 @@
         c2 = Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
         @inferred convert(Cartesian, c1)
         @inferred convert(LatLonAlt, c2)
+      end
+
+      # conversion GeocentricLatLonAlt <> Cartesian is tested in the next section
+      @testset "GeocentricLatLonAlt <> Cartesian" begin
+
       end
     end
 

--- a/test/crs/crsapi.jl
+++ b/test/crs/crsapi.jl
@@ -16,7 +16,6 @@
     @test datum(c) === WGS84Latest
     c = AuthalicLatLon(T(1), T(1))
     @test datum(c) === WGS84Latest
-
   end
 
   @testset "ncoords" begin

--- a/test/crs/crsapi.jl
+++ b/test/crs/crsapi.jl
@@ -16,6 +16,7 @@
     @test datum(c) === WGS84Latest
     c = AuthalicLatLon(T(1), T(1))
     @test datum(c) === WGS84Latest
+
   end
 
   @testset "ncoords" begin
@@ -34,6 +35,10 @@
     c = LatLon(T(30), T(60))
     @test CoordRefSystems.ncoords(c) == 2
     c = LatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.ncoords(c) == 3
+    c = GeocentricLatLon(T(30), T(60))
+    @test CoordRefSystems.ncoords(c) == 2
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
     @test CoordRefSystems.ncoords(c) == 3
     c = Mercator(T(1), T(1))
     @test CoordRefSystems.ncoords(c) == 2
@@ -58,6 +63,10 @@
     @test CoordRefSystems.ndims(c) == 3
     c = LatLonAlt(T(30), T(60), T(1))
     @test CoordRefSystems.ndims(c) == 3
+    c = GeocentricLatLon(T(30), T(60))
+    @test CoordRefSystems.ndims(c) == 3
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.ndims(c) == 3
     c = Mercator(T(1), T(1))
     @test CoordRefSystems.ndims(c) == 2
     c = ShiftedMercator(T(1), T(2))
@@ -79,6 +88,10 @@
     @test CoordRefSystems.names(c) == (:lat, :lon)
     c = LatLonAlt(T(30), T(60), T(1))
     @test CoordRefSystems.names(c) == (:lat, :lon, :alt)
+    c = GeocentricLatLon(T(30), T(60))
+    @test CoordRefSystems.names(c) == (:lat, :lon)
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.names(c) == (:lat, :lon, :alt)
     c = Mercator(T(1), T(1))
     @test CoordRefSystems.names(c) == (:x, :y)
     c = ShiftedMercator(T(1), T(2))
@@ -99,6 +112,10 @@
     c = LatLon(T(30), T(60))
     @test CoordRefSystems.values(c) == (T(30) * °, T(60) * °)
     c = LatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.values(c) == (T(30) * °, T(60) * °, T(1) * m)
+    c = GeocentricLatLon(T(30), T(60))
+    @test CoordRefSystems.values(c) == (T(30) * °, T(60) * °)
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
     @test CoordRefSystems.values(c) == (T(30) * °, T(60) * °, T(1) * m)
     c = Mercator(T(1), T(2))
     @test CoordRefSystems.values(c) == (T(1) * m, T(2) * m)
@@ -123,6 +140,8 @@
     @test CoordRefSystems.raw(c) == (T(60), T(30), T(1))
     c = GeocentricLatLon(T(30), T(60))
     @test CoordRefSystems.raw(c) == (T(60), T(30))
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.raw(c) == (T(60), T(30), T(1))
     c = AuthalicLatLon(T(30), T(60))
     @test CoordRefSystems.raw(c) == (T(60), T(30))
     c = Mercator(T(1), T(2))
@@ -205,6 +224,8 @@
     @test CoordRefSystems.constructor(c) === LatLonAlt{WGS84Latest}
     c = GeocentricLatLon(T(30), T(60))
     @test CoordRefSystems.constructor(c) === GeocentricLatLon{WGS84Latest}
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.constructor(c) === GeocentricLatLonAlt{WGS84Latest}
     c = AuthalicLatLon(T(30), T(60))
     @test CoordRefSystems.constructor(c) === AuthalicLatLon{WGS84Latest}
     c = Mercator(T(1), T(1))
@@ -252,6 +273,9 @@
     rv = CoordRefSystems.raw(c)
     @test CoordRefSystems.reconstruct(typeof(c), rv) == c
     c = GeocentricLatLon(T(30), T(60))
+    rv = CoordRefSystems.raw(c)
+    @test CoordRefSystems.reconstruct(typeof(c), rv) == c
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
     rv = CoordRefSystems.raw(c)
     @test CoordRefSystems.reconstruct(typeof(c), rv) == c
     c = AuthalicLatLon(T(30), T(60))
@@ -304,6 +328,8 @@
     @test CoordRefSystems.lentype(c) == typeof(T(1) * m)
     c = GeocentricLatLon(T(30), T(60))
     @test CoordRefSystems.lentype(c) == typeof(T(1) * m)
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.lentype(c) == typeof(T(1) * m)
     c = AuthalicLatLon(T(30), T(60))
     @test CoordRefSystems.lentype(c) == typeof(T(1) * m)
     c = Mercator(T(1), T(1))
@@ -343,6 +369,8 @@
     @test CoordRefSystems.mactype(c) == T
     c = GeocentricLatLon(T(30), T(60))
     @test CoordRefSystems.mactype(c) == T
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.mactype(c) == T
     c = AuthalicLatLon(T(30), T(60))
     @test CoordRefSystems.mactype(c) == T
     c = Mercator(T(1), T(1))
@@ -376,6 +404,7 @@
     equaltest(LatLon)
     equaltest(LatLonAlt)
     equaltest(GeocentricLatLon)
+    equaltest(GeocentricLatLonAlt)
     equaltest(AuthalicLatLon)
     equaltest(Mercator)
     equaltest(WebMercator)
@@ -397,6 +426,8 @@
     isapproxtest3D(Spherical)
     isapproxtest3D(LatLon)
     isapproxtest3D(LatLonAlt)
+    isapproxtest3D(GeocentricLatLon)
+    isapproxtest3D(GeocentricLatLonAlt)
     isapproxtest3D(Mercator)
     isapproxtest3D(WebMercator)
     isapproxtest3D(PlateCarree)
@@ -419,6 +450,10 @@
     tol = CoordRefSystems.atol(T) * m
     c = LatLon(T(1), T(1))
     @test CoordRefSystems.tol(c) == tol
+    c = LatLonAlt(T(1), T(1), T(1))
+    @test CoordRefSystems.tol(c) == tol
+    c = GeocentricLatLon(T(1), T(1))
+    @test CoordRefSystems.tol(c) == tol
     c = Cartesian(T(1), T(1))
     @test CoordRefSystems.tol(c) == tol
     c = Polar(T(1), 1.0f0)
@@ -439,6 +474,11 @@
     c2 = LatLon(45.0f0, 90.0f0)
     @test typeof(convert(C, c1)) === C
     @test typeof(convert(C, c2)) === C
+    c1 = GeocentricLatLon(45.0, 90.0)
+    c2 = GeocentricLatLon(45.0f0, 90.0f0)
+    @test typeof(convert(C, c1)) === C
+    @test typeof(convert(C, c2)) === C
+
     C = typeof(PlateCarree(T(0), T(0)))
     c1 = Cartesian(1.0, 1.0)
     c2 = Cartesian(1.0f0, 1.0f0)
@@ -462,6 +502,8 @@
     @test convert(Cartesian, c) === c
     c = LatLon(T(45), T(90))
     @test convert(LatLon, c) === c
+    c = GeocentricLatLon(T(45), T(90))
+    @test convert(GeocentricLatLon, c) === c
     c = OrthoNorth(T(1), T(1))
     @test convert(OrthoNorth, c) === c
 
@@ -478,5 +520,9 @@
     @inferred convert(C, c1)
     @inferred convert(C, c2)
     @inferred convert(Cartesian, c3)
+    c1 = GeocentricLatLon(45.0, 90.0)
+    c2 = GeocentricLatLon(45.0f0, 90.0f0)
+    @inferred convert(C, c1)
+    @inferred convert(C, c2)
   end
 end

--- a/test/crs/crsapi.jl
+++ b/test/crs/crsapi.jl
@@ -8,6 +8,14 @@
     @test datum(c) === NoDatum
     c = LatLon(T(1), T(1))
     @test datum(c) === WGS84Latest
+    c = LatLonAlt(T(1), T(1), T(1))
+    @test datum(c) === WGS84Latest
+    c = GeocentricLatLon(T(1), T(1))
+    @test datum(c) === WGS84Latest
+    c = GeocentricLatLonAlt(T(1), T(1), T(1))
+    @test datum(c) === WGS84Latest
+    c = AuthalicLatLon(T(1), T(1))
+    @test datum(c) === WGS84Latest
   end
 
   @testset "ncoords" begin
@@ -156,6 +164,8 @@
     @test CoordRefSystems.units(c) == (°, °, m)
     c = GeocentricLatLon(T(30), T(60))
     @test CoordRefSystems.units(c) == (°, °)
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.units(c) == (°, °, m)
     c = AuthalicLatLon(T(30), T(60))
     @test CoordRefSystems.units(c) == (°, °)
     c = Mercator(T(1), T(1))


### PR DESCRIPTION
Add support for GeocentricLatLonAlt

Add direct conversion  GeocentricLatLon <> Cartesian
Add direct conversion  GeocentricLatLon <> Projection
Add conversion GeocentricLatLonAlt<>LatLonAlt

Add tests for Geocentric data

In many practical cases, the latitude and longitude of ESA satellite data are given in Geocentric instead of Geodesic coordinates. GeocentriLatLonAlt converts the information into LatLon before adding the height and converting it into cartesian.

