### PR TITLE
Add `CoordRefSystems.code` function & Small fix in `Shift` constructor

### DIFF
--- a/src/get.jl
+++ b/src/get.jl
@@ -13,6 +13,8 @@ get(crsstr::AbstractString) = get(string2code(crsstr))
     CoordRefSystems.get(code)
 
 Get the CRS type from the EPSG/ESRI `code`.
+
+For the inverse operation, see the [`CoordRefSystems.code`](@ref) function.
 """
 function get(code::Type{<:CRSCode})
   throw(ArgumentError("""
@@ -24,36 +26,63 @@ function get(code::Type{<:CRSCode})
   """))
 end
 
+"""
+    CoordRefSystems.code(CRS)
+
+Get the EPSG/ESRI code from the `CRS` type.
+
+For the inverse operation, see the [`CoordRefSystems.get`](@ref) function.
+"""
+function code(crs::Type{<:CRS})
+  throw(ArgumentError("""
+  The provided CRS type `$crs` does not have an EPSG/ESRI code.
+  Please check https://github.com/JuliaEarth/CoordRefSystems.jl/blob/main/src/get.jl
+  """))
+end
+
+"""
+    @crscode(Code, CRS)
+
+Define both `get` and `code` functions for `Code` and `CRS`.
+"""
+macro crscode(Code, CRS)
+  expr = quote
+    get(::Type{$Code}) = $CRS
+    code(::Type{<:$CRS}) = $Code
+  end
+  esc(expr)
+end
+
 # ----------------
 # IMPLEMENTATIONS
 # ----------------
 
-get(::Type{EPSG{2157}}) = shift(TransverseMercator{0.99982,53.5°,IRENET95}, lonₒ=-8.0°, xₒ=600000.0m, yₒ=750000.0m)
-get(::Type{EPSG{3395}}) = Mercator{WGS84Latest}
-get(::Type{EPSG{3857}}) = WebMercator{WGS84Latest}
-get(::Type{EPSG{4208}}) = LatLon{Aratu}
-get(::Type{EPSG{4269}}) = LatLon{NAD83}
-get(::Type{EPSG{4326}}) = LatLon{WGS84Latest}
-get(::Type{EPSG{4618}}) = LatLon{SAD69}
-get(::Type{EPSG{4674}}) = LatLon{SIRGAS2000}
-get(::Type{EPSG{4988}}) = Cartesian3D{shift(ITRF{2000}, 2000.4)}
-get(::Type{EPSG{4989}}) = LatLonAlt{shift(ITRF{2000}, 2000.4)}
-get(::Type{EPSG{5527}}) = LatLon{SAD96}
-get(::Type{EPSG{9988}}) = Cartesian3D{ITRF{2020}}
-get(::Type{EPSG{10176}}) = Cartesian3D{IGS20}
-get(::Type{EPSG{27700}}) = shift(TransverseMercator{0.9996012717,49.0°,OSGB36}, lonₒ=-2.0°, xₒ=400000.0m, yₒ=-100000.0m)
-get(::Type{EPSG{29903}}) = shift(TransverseMercator{1.000035,53.5°,Ire65}, lonₒ=-8.0°, xₒ=200000.0m, yₒ=250000.0m)
-get(::Type{EPSG{32662}}) = PlateCarree{WGS84Latest}
-get(::Type{ESRI{54017}}) = Behrmann{WGS84Latest}
-get(::Type{ESRI{54030}}) = Robinson{WGS84Latest}
-get(::Type{ESRI{54034}}) = Lambert{WGS84Latest}
-get(::Type{ESRI{54042}}) = WinkelTripel{WGS84Latest}
-get(::Type{ESRI{102035}}) = Orthographic{SphericalMode,90°,WGS84Latest}
-get(::Type{ESRI{102037}}) = Orthographic{SphericalMode,-90°,WGS84Latest}
+@crscode EPSG{2157} shift(TransverseMercator{0.99982,53.5°,IRENET95}, lonₒ=-8.0°, xₒ=600000.0m, yₒ=750000.0m)
+@crscode EPSG{3395} Mercator{WGS84Latest}
+@crscode EPSG{3857} WebMercator{WGS84Latest}
+@crscode EPSG{4208} LatLon{Aratu}
+@crscode EPSG{4269} LatLon{NAD83}
+@crscode EPSG{4326} LatLon{WGS84Latest}
+@crscode EPSG{4618} LatLon{SAD69}
+@crscode EPSG{4674} LatLon{SIRGAS2000}
+@crscode EPSG{4988} Cartesian3D{shift(ITRF{2000}, 2000.4)}
+@crscode EPSG{4989} LatLonAlt{shift(ITRF{2000}, 2000.4)}
+@crscode EPSG{5527} LatLon{SAD96}
+@crscode EPSG{9988} Cartesian3D{ITRF{2020}}
+@crscode EPSG{10176} Cartesian3D{IGS20}
+@crscode EPSG{27700} shift(TransverseMercator{0.9996012717,49.0°,OSGB36}, lonₒ=-2.0°, xₒ=400000.0m, yₒ=-100000.0m)
+@crscode EPSG{29903} shift(TransverseMercator{1.000035,53.5°,Ire65}, lonₒ=-8.0°, xₒ=200000.0m, yₒ=250000.0m)
+@crscode EPSG{32662} PlateCarree{WGS84Latest}
+@crscode ESRI{54017} Behrmann{WGS84Latest}
+@crscode ESRI{54030} Robinson{WGS84Latest}
+@crscode ESRI{54034} Lambert{WGS84Latest}
+@crscode ESRI{54042} WinkelTripel{WGS84Latest}
+@crscode ESRI{102035} Orthographic{SphericalMode,90°,WGS84Latest}
+@crscode ESRI{102037} Orthographic{SphericalMode,-90°,WGS84Latest}
 
 for zone in 1:60
   NorthCode = 32600 + zone
   SouthCode = 32700 + zone
-  @eval get(::Type{EPSG{$NorthCode}}) = utmnorth($zone, datum=WGS84Latest)
-  @eval get(::Type{EPSG{$SouthCode}}) = utmsouth($zone, datum=WGS84Latest)
+  @eval @crscode EPSG{$NorthCode} utmnorth($zone, datum=WGS84Latest)
+  @eval @crscode EPSG{$SouthCode} utmsouth($zone, datum=WGS84Latest)
 end

--- a/src/shift.jl
+++ b/src/shift.jl
@@ -14,7 +14,7 @@ struct Shift{D<:Deg,M<:Met}
   yₒ::M
 end
 
-Shift(; lonₒ=0.0°, xₒ=0.0m, yₒ=0.0m) = Shift(asdeg(lonₒ), asmet(xₒ), asmet(yₒ))
+Shift(; lonₒ=0.0°, xₒ=0.0m, yₒ=0.0m) = Shift(float(asdeg(lonₒ)), float(asmet(xₒ)), float(asmet(yₒ)))
 
 """
     CoordRefSystems.shift(CRS::Type{<:Projected}; lonₒ=0.0°, xₒ=0.0m, yₒ=0.0m)

--- a/test/get.jl
+++ b/test/get.jl
@@ -1,41 +1,50 @@
 @testset "get" begin
   # EPSG/ESRI code
-  @test CoordRefSystems.get(EPSG{2157}) ===
-        CoordRefSystems.shift(TransverseMercator{0.99982,53.5°,IRENET95}, lonₒ=-8.0°, xₒ=600000.0m, yₒ=750000.0m)
-  @test CoordRefSystems.get(EPSG{3395}) === Mercator{WGS84Latest}
-  @test CoordRefSystems.get(EPSG{3857}) === WebMercator{WGS84Latest}
-  @test CoordRefSystems.get(EPSG{4208}) === LatLon{Aratu}
-  @test CoordRefSystems.get(EPSG{4269}) === LatLon{NAD83}
-  @test CoordRefSystems.get(EPSG{4326}) === LatLon{WGS84Latest}
-  @test CoordRefSystems.get(EPSG{4618}) === LatLon{SAD69}
-  @test CoordRefSystems.get(EPSG{4674}) === LatLon{SIRGAS2000}
-  @test CoordRefSystems.get(EPSG{4988}) === Cartesian{CoordRefSystems.shift(ITRF{2000}, 2000.4),3}
-  @test CoordRefSystems.get(EPSG{4989}) === LatLonAlt{CoordRefSystems.shift(ITRF{2000}, 2000.4)}
-  @test CoordRefSystems.get(EPSG{5527}) === LatLon{SAD96}
-  @test CoordRefSystems.get(EPSG{9988}) === Cartesian{ITRF{2020},3}
-  @test CoordRefSystems.get(EPSG{10176}) === Cartesian{IGS20,3}
-  @test CoordRefSystems.get(EPSG{27700}) ===
-        CoordRefSystems.shift(TransverseMercator{0.9996012717,49.0°,OSGB36}, lonₒ=-2.0°, xₒ=400000.0m, yₒ=-100000.0m)
-  @test CoordRefSystems.get(EPSG{29903}) ===
-        CoordRefSystems.shift(TransverseMercator{1.000035,53.5°,Ire65}, lonₒ=-8.0°, xₒ=200000.0m, yₒ=250000.0m)
-  @test CoordRefSystems.get(EPSG{32662}) === PlateCarree{WGS84Latest}
-  @test CoordRefSystems.get(ESRI{54017}) === Behrmann{WGS84Latest}
-  @test CoordRefSystems.get(ESRI{54030}) === Robinson{WGS84Latest}
-  @test CoordRefSystems.get(ESRI{54034}) === Lambert{WGS84Latest}
-  @test CoordRefSystems.get(ESRI{54042}) === WinkelTripel{WGS84Latest}
-  @test CoordRefSystems.get(ESRI{102035}) ===
-        CoordRefSystems.Orthographic{CoordRefSystems.SphericalMode,90°,WGS84Latest}
-  @test CoordRefSystems.get(ESRI{102037}) ===
-        CoordRefSystems.Orthographic{CoordRefSystems.SphericalMode,-90°,WGS84Latest}
+  gettest(
+    EPSG{2157},
+    CoordRefSystems.shift(TransverseMercator{0.99982,53.5°,IRENET95}, lonₒ=-8.0°, xₒ=600000.0m, yₒ=750000.0m)
+  )
+  gettest(EPSG{3395}, Mercator{WGS84Latest})
+  gettest(EPSG{3857}, WebMercator{WGS84Latest})
+  gettest(EPSG{4208}, LatLon{Aratu})
+  gettest(EPSG{4269}, LatLon{NAD83})
+  gettest(EPSG{4326}, LatLon{WGS84Latest})
+  gettest(EPSG{4618}, LatLon{SAD69})
+  gettest(EPSG{4674}, LatLon{SIRGAS2000})
+  gettest(EPSG{4988}, Cartesian{CoordRefSystems.shift(ITRF{2000}, 2000.4),3})
+  gettest(EPSG{4989}, LatLonAlt{CoordRefSystems.shift(ITRF{2000}, 2000.4)})
+  gettest(EPSG{5527}, LatLon{SAD96})
+  gettest(EPSG{9988}, Cartesian{ITRF{2020},3})
+  gettest(EPSG{10176}, Cartesian{IGS20,3})
+  gettest(
+    EPSG{27700},
+    CoordRefSystems.shift(TransverseMercator{0.9996012717,49.0°,OSGB36}, lonₒ=-2.0°, xₒ=400000.0m, yₒ=-100000.0m)
+  )
+  gettest(
+    EPSG{29903},
+    CoordRefSystems.shift(TransverseMercator{1.000035,53.5°,Ire65}, lonₒ=-8.0°, xₒ=200000.0m, yₒ=250000.0m)
+  )
+  gettest(EPSG{32662}, PlateCarree{WGS84Latest})
+  gettest(ESRI{54017}, Behrmann{WGS84Latest})
+  gettest(ESRI{54030}, Robinson{WGS84Latest})
+  gettest(ESRI{54034}, Lambert{WGS84Latest})
+  gettest(ESRI{54042}, WinkelTripel{WGS84Latest})
+  gettest(ESRI{102035}, CoordRefSystems.Orthographic{CoordRefSystems.SphericalMode,90°,WGS84Latest})
+  gettest(ESRI{102037}, CoordRefSystems.Orthographic{CoordRefSystems.SphericalMode,-90°,WGS84Latest})
 
   for zone in 1:60
     NorthCode = 32600 + zone
     SouthCode = 32700 + zone
-    @test CoordRefSystems.get(EPSG{NorthCode}) === utmnorth(zone, datum=WGS84Latest)
-    @test CoordRefSystems.get(EPSG{SouthCode}) === utmsouth(zone, datum=WGS84Latest)
+    gettest(EPSG{NorthCode}, utmnorth(zone, datum=WGS84Latest))
+    gettest(EPSG{SouthCode}, utmsouth(zone, datum=WGS84Latest))
   end
 
   # CRS string
   str = wktstring(EPSG{3395})
   @test CoordRefSystems.get(str) === Mercator{WGS84Latest}
+
+  # error: the provided Code is not mapped to a CRS type yet
+  @test_throws ArgumentError CoordRefSystems.get(EPSG{0})
+  # error: the provided CRS type does not have an EPSG/ESRI code
+  @test_throws ArgumentError CoordRefSystems.code(Mercator)
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -110,3 +110,13 @@ function crsstringtest(code)
   str = wktstring(code, format="WKT1_ESRI", multiline=true)
   @test CoordRefSystems.string2code(str) === code
 end
+
+function gettest(code, CRS)
+  @test CoordRefSystems.get(code) === CRS
+  # inverse operation
+  @test CoordRefSystems.code(CRS) === code
+  # with instance type
+  n = CoordRefSystems.ncoords(CRS)
+  c = CRS(ntuple(_ -> T(0), n)...)
+  @test CoordRefSystems.code(typeof(c)) === code
+end


### PR DESCRIPTION
This function is the inverse of `CoordRefSystems.get` function and will be useful in future PRs.

This PR also adds a small fix in `Shift` constructor to avoid creating non-float parameters.