### PR TITLE
Add comparison and sorting for geographic types

### DIFF
--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -12,7 +12,7 @@ using Rotations: RotXYZ
 using StaticArrays: SVector
 
 import Random
-import Base: ==
+import Base: ==,isless
 
 include("utils.jl")
 include("ioutils.jl")
@@ -99,6 +99,9 @@ export
 
   # codes
   EPSG,
-  ESRI
+  ESRI,
 
+  # functions
+  sort_by_field,
+  sort_by_field!
 end

--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -74,6 +74,7 @@ export
   GeodeticLatLon,
   GeodeticLatLonAlt,
   GeocentricLatLon,
+  GeocentricLatLonAlt,
   AuthalicLatLon,
   LatLon,
   LatLonAlt,

--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -12,7 +12,7 @@ using Rotations: RotXYZ
 using StaticArrays: SVector
 
 import Random
-import Base: ==,isless
+import Base: ==, isless
 
 include("utils.jl")
 include("ioutils.jl")

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -416,13 +416,13 @@ function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::GeocentricLatL
 end
 
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::LatLonAlt{Datum}) where {Datum}
-  geocentric = convert(GeocentricLatLon, LatLon{Datum}(coords.lat, coords.lon))
-  GeocentricLatLonAlt{Datum}(geocentric.lat, geocentric.lon, coords.alt)
+  lla = convert(GeocentricLatLon, LatLon{Datum}(coords.lat, coords.lon))
+  GeocentricLatLonAlt{Datum}(lla.lat, lla.lon, coords.alt)
 end
 
 function Base.convert(::Type{LatLonAlt{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum}
-  geodetic = convert(LatLon, GeocentricLatLon{Datum}(coords.lat, coords.lon))
-  LatLonAlt{Datum}(geodetic.lat, geodetic.lon, coords.alt)
+  lla = convert(LatLon, GeocentricLatLon{Datum}(coords.lat, coords.lon))
+  LatLonAlt{Datum}(lla.lat, lla.lon, coords.alt)
 end
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::LatLon{Datum}) where {Datum}

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -531,3 +531,30 @@ Base.convert(::Type{GeocentricLatLonAlt}, coords::CRS{Datum}) where {Datum} =
   convert(GeocentricLatLonAlt{Datum}, coords)
 
 Base.convert(::Type{AuthalicLatLon}, coords::CRS{Datum}) where {Datum} = convert(AuthalicLatLon{Datum}, coords)
+
+
+
+
+#  Trasform the field of a Geographic type to a Tuple for comparison
+@inline _toTuple(x::T) where {T<:CoordRefSystems.Geographic} = Tuple([getfield(x,name) for name in fieldnames(T)])
+
+
+
+
+@inline function _toTuple(x::T,s::AbstractVector{Symbol}) where {T<:CoordRefSystems.Geographic}
+  @assert all(@. hasfield(T,s)) "Field $s not found in $T"
+  _fieldname=fieldnames(T) |> names-> filter(x->x ∉ s,names) |> names-> (s...,names...)
+  Tuple([getfield(x,name) for name in _fieldname])
+end
+
+@inline _toTuple(x::T,s::Symbol) where {T<:CoordRefSystems.Geographic} = _toTuple(x,[s])
+@inline _toTuple(x::T,s::String) where {T<:CoordRefSystems.Geographic} = _toTuple(x,Symbol(s))
+@inline _toTuple(x::T,s::AbstractVector{String}) where {T<:CoordRefSystems.Geographic} = _toTuple(x,Symbol.(s))
+
+# Lexiconomical comparison between two geographic coordinates of the same type
+Base.isless(x::T, y::T) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x),_toTuple(y))
+
+Base.isless(x::T, y::T,s::Symbol) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x,s),_toTuple(y,s))
+Base.isless(x::T, y::T,s::String) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x,s),_toTuple(y,s))
+Base.isless(x::T, y::T,s::AbstractVector{Symbol}) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x,s),_toTuple(y,s))
+Base.isless(x::T, y::T,s::AbstractVector{String}) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x,s),_toTuple(y,s))

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -554,7 +554,47 @@ end
 # Lexiconomical comparison between two geographic coordinates of the same type
 Base.isless(x::T, y::T) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x),_toTuple(y))
 
+
+"""
+  isless(x::T, y::T,s::S) where {T<:CoordRefSystems.Geographic,S}
+
+Lexiconomical comparison between two geographic coordinates of the same type `T` by a field `s` of type `S`. Where `S` could be a String, Symbol or a Vector of Strings or Symbols.
+If only a partial order is defined, the rest of the rest of the field are sorted in the order of the remaining namefields.
+
+## Examples
+```jldoctest
+julia> a1= LatLon(1,2); a2= LatLon(2,1);
+julia> isless(a1,a2)
+true
+julia> isless(a1,a2,:lon)
+false
+
+See also [`sort_by_field`](@ref).
+"""
 Base.isless(x::T, y::T,s::Symbol) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x,s),_toTuple(y,s))
 Base.isless(x::T, y::T,s::String) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x,s),_toTuple(y,s))
 Base.isless(x::T, y::T,s::AbstractVector{Symbol}) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x,s),_toTuple(y,s))
 Base.isless(x::T, y::T,s::AbstractVector{String}) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x,s),_toTuple(y,s))
+
+
+"""
+  sort_by_field(x::T,s::S;kwargs...)
+
+Sort an array of `Geographic` type `T` by a field `s` of type `S`. Where `S` could be a String, Symbol or a Vector of Strings or Symbols.
+It is an alias for `sort(x;lt=(x,y)->isless(x,y,s),kwargs...)`.
+"""
+sort_by_field(x::AbstractArray{T},s::Symbol;kwargs...) where {T<:CoordRefSystems.Geographic} = sort(x;lt=(x,y)->isless(x,y,s),kwargs...)
+sort_by_field(x::AbstractArray{T},s::String;kwargs...) where {T<:CoordRefSystems.Geographic} = sort(x;lt=(x,y)->isless(x,y,s),kwargs...)
+sort_by_field(x::AbstractArray{T},s::AbstractVector{Symbol};kwargs...) where {T<:CoordRefSystems.Geographic} = sort(x;lt=(x,y)->isless(x,y,s),kwargs...)
+sort_by_field(x::AbstractArray{T},s::AbstractVector{String};kwargs...) where {T<:CoordRefSystems.Geographic} = sort(x;lt=(x,y)->isless(x,y,s),kwargs...)
+
+"""
+  sort_by_field!(x::T,s::S;kwargs...)
+
+In-place sort an array of `Geographic` type `T` by a field `s` of type `S`. Where `S` could be a String, Symbol or a Vector of Strings or Symbols. It is an
+alias for `sort!(x;lt=(x,y)->isless(x,y,s),kwargs...)`.
+"""
+sort_by_field!(x::AbstractArray{T},s::Symbol;kwargs...) where {T<:CoordRefSystems.Geographic} = sort!(x,lt=(x,y)->isless(x,y,s),kwargs...)
+sort_by_field!(x::AbstractArray{T},s::String;kwargs...) where {T<:CoordRefSystems.Geographic} = sort!(x,lt=(x,y)->isless(x,y,s),kwargs...)
+sort_by_field!(x::AbstractArray{T},s::AbstractVector{Symbol};kwargs...) where {T<:CoordRefSystems.Geographic} = sort!(x,lt=(x,y)->isless(x,y,s),kwargs...)
+sort_by_field!(x::AbstractArray{T},s::AbstractVector{String};kwargs...) where {T<:CoordRefSystems.Geographic} = sort!(x,lt=(x,y)->isless(x,y,s),kwargs...)

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -216,8 +216,8 @@ Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLon{Datum}}) where {Dat
 Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLon}) = rand(rng, GeocentricLatLon{WGS84Latest})
 
 """
-    GeoCentricLatLonAlt(lat, lon, alt)
-    GeoCentricLatLonAlt{Datum}(lat, lon, alt)
+    GeocentricLatLonAlt(lat, lon, alt)
+    GeocentricLatLonAlt{Datum}(lat, lon, alt)
 
 Geocentric latitude `lat ∈ [-90°,90°]` and longitude `lon ∈ [-180°,180°]` in angular units (default to degree)
 and altitude in length units (default to meter) with a given `Datum` (default to `WGS84Latest`).
@@ -440,6 +440,17 @@ function Base.convert(::Type{LatLon{Datum}}, coords::Cartesian{Datum,3}) where {
   lla = convert(LatLonAlt{Datum}, coords)
   convert(LatLon{Datum}, lla)
 end
+
+function Base.convert(::Type{Cartesian{Datum}}, coords::GeocentricLatLon{Datum}) where {Datum}
+  geocentric_lla = convert(GeocentricLatLonAlt{Datum}, coords);
+  return convert(Cartesian{Datum}, geocentric_lla)
+end
+
+function Base.convert(::Type{GeocentricLatLon{Datum}}, coords::Cartesian{Datum,3}) where {Datum}
+  geocentric_lla = convert(GeocentricLatLonAlt{Datum}, coords);
+  return convert(GeocentricLatLon{Datum}, geocentric_lla)
+end
+
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum}
   geodesic_coords = convert(LatLonAlt, coords);

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -513,6 +513,7 @@ function Base.convert(::Type{GeocentricLatLon{Datumₜ}}, coords::GeocentricLatL
   cartₜ = convert(Cartesian{Datumₜ}, cartₛ)
   convert(GeocentricLatLon{Datumₜ}, cartₜ)
 end
+
 # avoid converting coordinates with the same datum as the first argument
 Base.convert(::Type{GeocentricLatLon{Datum}}, coords::GeocentricLatLon{Datum}) where {Datum} = coords
 

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -532,28 +532,21 @@ Base.convert(::Type{GeocentricLatLonAlt}, coords::CRS{Datum}) where {Datum} =
 
 Base.convert(::Type{AuthalicLatLon}, coords::CRS{Datum}) where {Datum} = convert(AuthalicLatLon{Datum}, coords)
 
-
-
-
 #  Trasform the field of a Geographic type to a Tuple for comparison
-@inline _toTuple(x::T) where {T<:CoordRefSystems.Geographic} = Tuple([getfield(x,name) for name in fieldnames(T)])
+@inline _toTuple(x::T) where {T<:CoordRefSystems.Geographic} = Tuple([getfield(x, name) for name in fieldnames(T)])
 
-
-
-
-@inline function _toTuple(x::T,s::AbstractVector{Symbol}) where {T<:CoordRefSystems.Geographic}
-  @assert all(@. hasfield(T,s)) "Field $s not found in $T"
-  _fieldname=fieldnames(T) |> names-> filter(x->x ∉ s,names) |> names-> (s...,names...)
-  Tuple([getfield(x,name) for name in _fieldname])
+@inline function _toTuple(x::T, s::AbstractVector{Symbol}) where {T<:CoordRefSystems.Geographic}
+  @assert all(@. hasfield(T, s)) "Field $s not found in $T"
+  _fieldname=fieldnames(T) |> names->filter(x->x ∉ s, names) |> names -> (s..., names...)
+  Tuple([getfield(x, name) for name in _fieldname])
 end
 
-@inline _toTuple(x::T,s::Symbol) where {T<:CoordRefSystems.Geographic} = _toTuple(x,[s])
-@inline _toTuple(x::T,s::String) where {T<:CoordRefSystems.Geographic} = _toTuple(x,Symbol(s))
-@inline _toTuple(x::T,s::AbstractVector{String}) where {T<:CoordRefSystems.Geographic} = _toTuple(x,Symbol.(s))
+@inline _toTuple(x::T, s::Symbol) where {T<:CoordRefSystems.Geographic} = _toTuple(x, [s])
+@inline _toTuple(x::T, s::String) where {T<:CoordRefSystems.Geographic} = _toTuple(x, Symbol(s))
+@inline _toTuple(x::T, s::AbstractVector{String}) where {T<:CoordRefSystems.Geographic} = _toTuple(x, Symbol.(s))
 
 # Lexiconomical comparison between two geographic coordinates of the same type
-Base.isless(x::T, y::T) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x),_toTuple(y))
-
+Base.isless(x::T, y::T) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x), _toTuple(y))
 
 """
   isless(x::T, y::T,s::S) where {T<:CoordRefSystems.Geographic,S}
@@ -571,11 +564,12 @@ false
 
 See also [`sort_by_field`](@ref).
 """
-Base.isless(x::T, y::T,s::Symbol) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x,s),_toTuple(y,s))
-Base.isless(x::T, y::T,s::String) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x,s),_toTuple(y,s))
-Base.isless(x::T, y::T,s::AbstractVector{Symbol}) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x,s),_toTuple(y,s))
-Base.isless(x::T, y::T,s::AbstractVector{String}) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x,s),_toTuple(y,s))
-
+Base.isless(x::T, y::T, s::Symbol) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x, s), _toTuple(y, s))
+Base.isless(x::T, y::T, s::String) where {T<:CoordRefSystems.Geographic} = isless(_toTuple(x, s), _toTuple(y, s))
+Base.isless(x::T, y::T, s::AbstractVector{Symbol}) where {T<:CoordRefSystems.Geographic} =
+  isless(_toTuple(x, s), _toTuple(y, s))
+Base.isless(x::T, y::T, s::AbstractVector{String}) where {T<:CoordRefSystems.Geographic} =
+  isless(_toTuple(x, s), _toTuple(y, s))
 
 """
   sort_by_field(x::T,s::S;kwargs...)
@@ -583,10 +577,14 @@ Base.isless(x::T, y::T,s::AbstractVector{String}) where {T<:CoordRefSystems.Geog
 Sort an array of `Geographic` type `T` by a field `s` of type `S`. Where `S` could be a String, Symbol or a Vector of Strings or Symbols.
 It is an alias for `sort(x;lt=(x,y)->isless(x,y,s),kwargs...)`.
 """
-sort_by_field(x::AbstractArray{T},s::Symbol;kwargs...) where {T<:CoordRefSystems.Geographic} = sort(x;lt=(x,y)->isless(x,y,s),kwargs...)
-sort_by_field(x::AbstractArray{T},s::String;kwargs...) where {T<:CoordRefSystems.Geographic} = sort(x;lt=(x,y)->isless(x,y,s),kwargs...)
-sort_by_field(x::AbstractArray{T},s::AbstractVector{Symbol};kwargs...) where {T<:CoordRefSystems.Geographic} = sort(x;lt=(x,y)->isless(x,y,s),kwargs...)
-sort_by_field(x::AbstractArray{T},s::AbstractVector{String};kwargs...) where {T<:CoordRefSystems.Geographic} = sort(x;lt=(x,y)->isless(x,y,s),kwargs...)
+sort_by_field(x::AbstractArray{T}, s::Symbol; kwargs...) where {T<:CoordRefSystems.Geographic} =
+  sort(x; lt=(x, y)->isless(x, y, s), kwargs...)
+sort_by_field(x::AbstractArray{T}, s::String; kwargs...) where {T<:CoordRefSystems.Geographic} =
+  sort(x; lt=(x, y)->isless(x, y, s), kwargs...)
+sort_by_field(x::AbstractArray{T}, s::AbstractVector{Symbol}; kwargs...) where {T<:CoordRefSystems.Geographic} =
+  sort(x; lt=(x, y)->isless(x, y, s), kwargs...)
+sort_by_field(x::AbstractArray{T}, s::AbstractVector{String}; kwargs...) where {T<:CoordRefSystems.Geographic} =
+  sort(x; lt=(x, y)->isless(x, y, s), kwargs...)
 
 """
   sort_by_field!(x::T,s::S;kwargs...)
@@ -594,7 +592,11 @@ sort_by_field(x::AbstractArray{T},s::AbstractVector{String};kwargs...) where {T<
 In-place sort an array of `Geographic` type `T` by a field `s` of type `S`. Where `S` could be a String, Symbol or a Vector of Strings or Symbols. It is an
 alias for `sort!(x;lt=(x,y)->isless(x,y,s),kwargs...)`.
 """
-sort_by_field!(x::AbstractArray{T},s::Symbol;kwargs...) where {T<:CoordRefSystems.Geographic} = sort!(x,lt=(x,y)->isless(x,y,s),kwargs...)
-sort_by_field!(x::AbstractArray{T},s::String;kwargs...) where {T<:CoordRefSystems.Geographic} = sort!(x,lt=(x,y)->isless(x,y,s),kwargs...)
-sort_by_field!(x::AbstractArray{T},s::AbstractVector{Symbol};kwargs...) where {T<:CoordRefSystems.Geographic} = sort!(x,lt=(x,y)->isless(x,y,s),kwargs...)
-sort_by_field!(x::AbstractArray{T},s::AbstractVector{String};kwargs...) where {T<:CoordRefSystems.Geographic} = sort!(x,lt=(x,y)->isless(x,y,s),kwargs...)
+sort_by_field!(x::AbstractArray{T}, s::Symbol; kwargs...) where {T<:CoordRefSystems.Geographic} =
+  sort!(x, lt=(x, y)->isless(x, y, s), kwargs...)
+sort_by_field!(x::AbstractArray{T}, s::String; kwargs...) where {T<:CoordRefSystems.Geographic} =
+  sort!(x, lt=(x, y)->isless(x, y, s), kwargs...)
+sort_by_field!(x::AbstractArray{T}, s::AbstractVector{Symbol}; kwargs...) where {T<:CoordRefSystems.Geographic} =
+  sort!(x, lt=(x, y)->isless(x, y, s), kwargs...)
+sort_by_field!(x::AbstractArray{T}, s::AbstractVector{String}; kwargs...) where {T<:CoordRefSystems.Geographic} =
+  sort!(x, lt=(x, y)->isless(x, y, s), kwargs...)

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -263,8 +263,6 @@ Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLonAlt{Datum}}) where {
 
 Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLonAlt}) = rand(rng, GeocentricLatLonAlt{WGS84Latest})
 
-# ------------
-
 """
     AuthalicLatLon(lat, lon)
     AuthalicLatLon{Datum}(lat, lon)

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -415,7 +415,6 @@ function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::GeocentricLatL
   GeocentricLatLonAlt{Datum}(coords.lat, coords.lon, zero(T) * m)
 end
 
-# Cross conversion between LatLonAlt and GeocentricLatLonAlt
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::LatLonAlt{Datum}) where {Datum}
   geocentric = convert(GeocentricLatLon, LatLon{Datum}(coords.lat, coords.lon))
   GeocentricLatLonAlt{Datum}(geocentric.lat, geocentric.lon, coords.alt)
@@ -425,7 +424,6 @@ function Base.convert(::Type{LatLonAlt{Datum}}, coords::GeocentricLatLonAlt{Datu
   geodetic = convert(LatLon, GeocentricLatLon{Datum}(coords.lat, coords.lon))
   LatLonAlt{Datum}(geodetic.lat, geodetic.lon, coords.alt)
 end
-###################################################################
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::LatLon{Datum}) where {Datum}
   lla = convert(LatLonAlt{Datum}, coords)
@@ -448,13 +446,13 @@ function Base.convert(::Type{GeocentricLatLon{Datum}}, coords::Cartesian{Datum,3
 end
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum}
-  _coords = convert(LatLonAlt, coords)
-  convert(Cartesian{Datum}, _coords)
+  lla = convert(LatLonAlt, coords)
+  convert(Cartesian{Datum}, lla)
 end
 
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::Cartesian{Datum,3}) where {Datum}
-  _coords = convert(LatLonAlt, coords)
-  convert(GeocentricLatLonAlt{Datum}, _coords)
+  lla = convert(LatLonAlt, coords)
+  convert(GeocentricLatLonAlt{Datum}, lla)
 end
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::LatLonAlt{Datum}) where {Datum}

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -216,6 +216,56 @@ Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLon{Datum}}) where {Dat
 Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLon}) = rand(rng, GeocentricLatLon{WGS84Latest})
 
 """
+    GeoCentricLatLonAlt(lat, lon, alt)
+    GeoCentricLatLonAlt{Datum}(lat, lon, alt)
+
+Geocentric latitude `lat ∈ [-90°,90°]` and longitude `lon ∈ [-180°,180°]` in angular units (default to degree)
+and altitude in length units (default to meter) with a given `Datum` (default to `WGS84Latest`).
+"""
+struct GeocentricLatLonAlt{Datum,D<:Deg,M<:Met} <: Geographic{Datum}
+  lat::D
+  lon::D
+  alt::M
+end
+
+GeocentricLatLonAlt{Datum}(lat::D, lon::D, alt::M) where {Datum,D<:Deg,M<:Met} =
+  GeocentricLatLonAlt{Datum,float(D),float(M)}(checklat(lat), fixlon(lon), alt)
+GeocentricLatLonAlt{Datum}(lat::Deg, lon::Deg, alt::Met) where {Datum} =
+    GeocentricLatLonAlt{Datum}(promote(lat, lon)..., alt)
+GeocentricLatLonAlt{Datum}(lat::Deg, lon::Deg, alt::Len) where {Datum} =
+    GeocentricLatLonAlt{Datum}(lat, lon, uconvert(m, alt))
+GeocentricLatLonAlt{Datum}(lat::Rad, lon::Rad, alt::Len) where {Datum} =
+    GeocentricLatLonAlt{Datum}(rad2deg(lat), rad2deg(lon), alt)
+GeocentricLatLonAlt{Datum}(lat::Number, lon::Number, alt::Number) where {Datum} =
+    GeocentricLatLonAlt{Datum}(addunit(lat, °), addunit(lon, °), addunit(alt, m))
+
+GeocentricLatLonAlt(args...) = GeocentricLatLonAlt{WGS84Latest}(args...)
+
+Base.convert(::Type{GeocentricLatLonAlt{Datum,D,M}}, coords::GeocentricLatLonAlt{Datum}) where {Datum,D,M} =
+    GeocentricLatLonAlt{Datum,D,M}(coords.lat, coords.lon, coords.alt)
+
+raw(coords::GeocentricLatLonAlt) = ustrip(coords.lon), ustrip(coords.lat), ustrip(coords.alt) # reverse order
+
+constructor(::Type{<:GeocentricLatLonAlt{Datum}}) where {Datum} = GeocentricLatLonAlt{Datum}
+
+function reconstruct(C::Type{<:GeocentricLatLonAlt}, raw)
+    lon, lat, alt = raw .* units(C)
+    constructor(C)(lat, lon, alt) # reverse order
+end
+
+lentype(::Type{<:GeocentricLatLonAlt{Datum,D,M}}) where {Datum,D,M} = M
+
+==(coords₁::GeocentricLatLonAlt{Datum}, coords₂::GeocentricLatLonAlt{Datum}) where {Datum} =
+    coords₁.lat == coords₂.lat && coords₁.lon == coords₂.lon && coords₁.alt == coords₂.alt
+
+Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLonAlt{Datum}}) where {Datum} =
+    GeocentricLatLonAlt{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng), rand(rng))
+
+Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLonAlt}) = rand(rng, GeocentricLatLonAlt{WGS84Latest})
+
+# ------------
+
+"""
     AuthalicLatLon(lat, lon)
     AuthalicLatLon{Datum}(lat, lon)
 

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -535,6 +535,6 @@ Base.convert(::Type{LatLonAlt}, coords::CRS{Datum}) where {Datum} = convert(LatL
 
 Base.convert(::Type{GeocentricLatLon}, coords::CRS{Datum}) where {Datum} = convert(GeocentricLatLon{Datum}, coords)
 
-Base.convert(::Type{GeocentricLatLonAlt}, coords::CRS{Datum}) where {Datum} = convert(GeocentricLatLonAlts{Datum}, coords)
+Base.convert(::Type{GeocentricLatLonAlt}, coords::CRS{Datum}) where {Datum} = convert(GeocentricLatLonAlt{Datum}, coords)
 
 Base.convert(::Type{AuthalicLatLon}, coords::CRS{Datum}) where {Datum} = convert(AuthalicLatLon{Datum}, coords)

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -231,35 +231,35 @@ end
 GeocentricLatLonAlt{Datum}(lat::D, lon::D, alt::M) where {Datum,D<:Deg,M<:Met} =
   GeocentricLatLonAlt{Datum,float(D),float(M)}(checklat(lat), fixlon(lon), alt)
 GeocentricLatLonAlt{Datum}(lat::Deg, lon::Deg, alt::Met) where {Datum} =
-    GeocentricLatLonAlt{Datum}(promote(lat, lon)..., alt)
+  GeocentricLatLonAlt{Datum}(promote(lat, lon)..., alt)
 GeocentricLatLonAlt{Datum}(lat::Deg, lon::Deg, alt::Len) where {Datum} =
-    GeocentricLatLonAlt{Datum}(lat, lon, uconvert(m, alt))
+  GeocentricLatLonAlt{Datum}(lat, lon, uconvert(m, alt))
 GeocentricLatLonAlt{Datum}(lat::Rad, lon::Rad, alt::Len) where {Datum} =
-    GeocentricLatLonAlt{Datum}(rad2deg(lat), rad2deg(lon), alt)
+  GeocentricLatLonAlt{Datum}(rad2deg(lat), rad2deg(lon), alt)
 GeocentricLatLonAlt{Datum}(lat::Number, lon::Number, alt::Number) where {Datum} =
-    GeocentricLatLonAlt{Datum}(addunit(lat, °), addunit(lon, °), addunit(alt, m))
+  GeocentricLatLonAlt{Datum}(addunit(lat, °), addunit(lon, °), addunit(alt, m))
 
 GeocentricLatLonAlt(args...) = GeocentricLatLonAlt{WGS84Latest}(args...)
 
 Base.convert(::Type{GeocentricLatLonAlt{Datum,D,M}}, coords::GeocentricLatLonAlt{Datum}) where {Datum,D,M} =
-    GeocentricLatLonAlt{Datum,D,M}(coords.lat, coords.lon, coords.alt)
+  GeocentricLatLonAlt{Datum,D,M}(coords.lat, coords.lon, coords.alt)
 
 raw(coords::GeocentricLatLonAlt) = ustrip(coords.lon), ustrip(coords.lat), ustrip(coords.alt) # reverse order
 
 constructor(::Type{<:GeocentricLatLonAlt{Datum}}) where {Datum} = GeocentricLatLonAlt{Datum}
 
 function reconstruct(C::Type{<:GeocentricLatLonAlt}, raw)
-    lon, lat, alt = raw .* units(C)
-    constructor(C)(lat, lon, alt) # reverse order
+  lon, lat, alt = raw .* units(C)
+  constructor(C)(lat, lon, alt) # reverse order
 end
 
 lentype(::Type{<:GeocentricLatLonAlt{Datum,D,M}}) where {Datum,D,M} = M
 
 ==(coords₁::GeocentricLatLonAlt{Datum}, coords₂::GeocentricLatLonAlt{Datum}) where {Datum} =
-    coords₁.lat == coords₂.lat && coords₁.lon == coords₂.lon && coords₁.alt == coords₂.alt
+  coords₁.lat == coords₂.lat && coords₁.lon == coords₂.lon && coords₁.alt == coords₂.alt
 
 Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLonAlt{Datum}}) where {Datum} =
-    GeocentricLatLonAlt{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng), rand(rng))
+  GeocentricLatLonAlt{Datum}(-90 + 180 * rand(rng), -180 + 360 * rand(rng), rand(rng))
 
 Random.rand(rng::Random.AbstractRNG, ::Type{GeocentricLatLonAlt}) = rand(rng, GeocentricLatLonAlt{WGS84Latest})
 
@@ -410,7 +410,8 @@ function Base.convert(::Type{LatLonAlt{Datum}}, coords::LatLon{Datum}) where {Da
 end
 
 # Conversion from GeocentriLatLonAlt to GeocentriLatLonAlt
-Base.convert(::Type{GeocentricLatLon{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum} = GeocentricLatLon{Datum}(coords.lat, coords.lon)
+Base.convert(::Type{GeocentricLatLon{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum} =
+  GeocentricLatLon{Datum}(coords.lat, coords.lon)
 
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::GeocentricLatLon{Datum}) where {Datum}
   T = numtype(coords.lon)
@@ -419,17 +420,15 @@ end
 
 # Cross conversion between LatLonAlt and GeocentricLatLonAlt
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::LatLonAlt{Datum}) where {Datum}
-  geocentric = convert(GeocentricLatLon, LatLon{Datum}(coords.lat, coords.lon));
-  return GeocentricLatLonAlt{Datum}(geocentric.lat, geocentric.lon, coords.alt);
+  geocentric = convert(GeocentricLatLon, LatLon{Datum}(coords.lat, coords.lon))
+  GeocentricLatLonAlt{Datum}(geocentric.lat, geocentric.lon, coords.alt)
 end
 
 function Base.convert(::Type{LatLonAlt{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum}
-  geodetic  = convert(LatLon, GeocentricLatLon{Datum}(coords.lat, coords.lon));
-  return LatLonAlt{Datum}(geodetic.lat, geodetic.lon, coords.alt);
+  geodetic = convert(LatLon, GeocentricLatLon{Datum}(coords.lat, coords.lon))
+  LatLonAlt{Datum}(geodetic.lat, geodetic.lon, coords.alt)
 end
 ###################################################################
-
-
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::LatLon{Datum}) where {Datum}
   lla = convert(LatLonAlt{Datum}, coords)
@@ -442,26 +441,24 @@ function Base.convert(::Type{LatLon{Datum}}, coords::Cartesian{Datum,3}) where {
 end
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::GeocentricLatLon{Datum}) where {Datum}
-  geocentric_lla = convert(GeocentricLatLonAlt{Datum}, coords);
-  return convert(Cartesian{Datum}, geocentric_lla)
+  lla = convert(GeocentricLatLonAlt{Datum}, coords)
+  convert(Cartesian{Datum}, lla)
 end
 
 function Base.convert(::Type{GeocentricLatLon{Datum}}, coords::Cartesian{Datum,3}) where {Datum}
-  geocentric_lla = convert(GeocentricLatLonAlt{Datum}, coords);
-  return convert(GeocentricLatLon{Datum}, geocentric_lla)
+  lla = convert(GeocentricLatLonAlt{Datum}, coords)
+  convert(GeocentricLatLon{Datum}, lla)
 end
 
-
 function Base.convert(::Type{Cartesian{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum}
-  geodesic_coords = convert(LatLonAlt, coords);
-  return convert(Cartesian{Datum}, geodesic_coords)
+  _coords = convert(LatLonAlt, coords)
+  convert(Cartesian{Datum}, _coords)
 end
 
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::Cartesian{Datum,3}) where {Datum}
-  geodesic_coords = convert(LatLonAlt, coords);
-  return convert(GeocentricLatLonAlt{Datum}, geodesic_coords)
+  _coords = convert(LatLonAlt, coords)
+  convert(GeocentricLatLonAlt{Datum}, _coords)
 end
-
 
 function Base.convert(::Type{Cartesian{Datum}}, coords::LatLonAlt{Datum}) where {Datum}
   T = numtype(coords.lon)
@@ -516,10 +513,9 @@ end
 # avoid converting coordinates with the same datum as the first argument
 Base.convert(::Type{LatLon{Datum}}, coords::LatLon{Datum}) where {Datum} = coords
 
-
 function Base.convert(::Type{GeocentricLatLon{Datumₜ}}, coords::GeocentricLatLon{Datumₛ}) where {Datumₜ,Datumₛ}
-  cartₛ = convert(Cartesian{Datumₛ}, coords);
-  cartₜ = convert(Cartesian{Datumₜ}, cartₛ);
+  cartₛ = convert(Cartesian{Datumₛ}, coords)
+  cartₜ = convert(Cartesian{Datumₜ}, cartₛ)
   convert(GeocentricLatLon{Datumₜ}, cartₜ)
 end
 # avoid converting coordinates with the same datum as the first argument
@@ -535,6 +531,7 @@ Base.convert(::Type{LatLonAlt}, coords::CRS{Datum}) where {Datum} = convert(LatL
 
 Base.convert(::Type{GeocentricLatLon}, coords::CRS{Datum}) where {Datum} = convert(GeocentricLatLon{Datum}, coords)
 
-Base.convert(::Type{GeocentricLatLonAlt}, coords::CRS{Datum}) where {Datum} = convert(GeocentricLatLonAlt{Datum}, coords)
+Base.convert(::Type{GeocentricLatLonAlt}, coords::CRS{Datum}) where {Datum} =
+  convert(GeocentricLatLonAlt{Datum}, coords)
 
 Base.convert(::Type{AuthalicLatLon}, coords::CRS{Datum}) where {Datum} = convert(AuthalicLatLon{Datum}, coords)

--- a/src/crs/geographic.jl
+++ b/src/crs/geographic.jl
@@ -407,7 +407,6 @@ function Base.convert(::Type{LatLonAlt{Datum}}, coords::LatLon{Datum}) where {Da
   LatLonAlt{Datum}(coords.lat, coords.lon, zero(T) * m)
 end
 
-# Conversion from GeocentriLatLonAlt to GeocentriLatLonAlt
 Base.convert(::Type{GeocentricLatLon{Datum}}, coords::GeocentricLatLonAlt{Datum}) where {Datum} =
   GeocentricLatLon{Datum}(coords.lat, coords.lon)
 

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -115,32 +115,29 @@ include("projected/transversemercator.jl")
 # ----------
 # FALLBACKS
 # ----------
-function Base.convert(::Type{C},coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}}
-  return convert(C, convert(LatLon{Datum}, coords))
+function Base.convert(::Type{C}, coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}}
+  convert(C, convert(LatLon{Datum}, coords))
 end
 
 function Base.convert(::Type{GeocentricLatLon{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
-  return convert(GeocentricLatLon{Datum}, convert(LatLon{Datum}, coords))
+  convert(GeocentricLatLon{Datum}, convert(LatLon{Datum}, coords))
 end
 
 function Base.convert(::Type{C}, coords::GeocentricLatLonAlt{Datum}) where {Datum,C<:Projected{Datum}}
-  return convert(C, convert(GeocentricLatLon{Datum}, coords))
+  convert(C, convert(GeocentricLatLon{Datum}, coords))
 end
 
 function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
-  return convert(GeocentricLatLonAlt{Datum}, convert(GeocentricLatLon{Datum}, coords))
+  convert(GeocentricLatLonAlt{Datum}, convert(GeocentricLatLon{Datum}, coords))
 end
 
 function Base.convert(::Type{C}, coords::LatLonAlt{Datum}) where {Datum,C<:Projected{Datum}}
-  return convert(C, convert(LatLon{Datum}, coords))
+  convert(C, convert(LatLon{Datum}, coords))
 end
 
 function Base.convert(::Type{LatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
-  return convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
+  convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
 end
-
-
-
 
 function Base.convert(::Type{C}, coords::LatLon{Datum}) where {Datum,C<:Projected{Datum}}
   S = projshift(C)

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -115,6 +115,32 @@ include("projected/transversemercator.jl")
 # ----------
 # FALLBACKS
 # ----------
+function Base.convert(::Type{C},coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}}
+  return convert(C, convert(LatLon{Datum}, coords))
+end
+
+function Base.convert(::Type{GeocentricLatLon{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
+  return convert(GeocentricLatLon{Datum}, convert(LatLon{Datum}, coords))
+end
+
+function Base.convert(::Type{C}, coords::GeocentricLatLonAlt{Datum}) where {Datum,C<:Projected{Datum}}
+  return convert(C, convert(GeocentricLatLon{Datum}, coords))
+end
+
+function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
+  return convert(GeocentricLatLonAlt{Datum}, convert(GeocentricLatLon{Datum}, coords))
+end
+
+function Base.convert(::Type{C}, coords::LatLonAlt{Datum}) where {Datum,C<:Projected{Datum}}
+  return convert(C, convert(LatLon{Datum}, coords))
+end
+
+function Base.convert(::Type{LatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
+  return convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
+end
+
+
+
 
 function Base.convert(::Type{C}, coords::LatLon{Datum}) where {Datum,C<:Projected{Datum}}
   S = projshift(C)

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -116,17 +116,23 @@ include("projected/transversemercator.jl")
 # FALLBACKS
 # ----------
 
-Base.convert(::Type{C}, coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}} = convert(C, convert(LatLon{Datum}, coords))
+Base.convert(::Type{C}, coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}} =
+  convert(C, convert(LatLon{Datum}, coords))
 
-Base.convert(::Type{GeocentricLatLon{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} = convert(GeocentricLatLon{Datum}, convert(LatLon{Datum}, coords))
+Base.convert(::Type{GeocentricLatLon{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} =
+  convert(GeocentricLatLon{Datum}, convert(LatLon{Datum}, coords))
 
-Base.convert(::Type{C}, coords::GeocentricLatLonAlt{Datum}) where {Datum,C<:Projected{Datum}} = convert(C, convert(GeocentricLatLon{Datum}, coords))
+Base.convert(::Type{C}, coords::GeocentricLatLonAlt{Datum}) where {Datum,C<:Projected{Datum}} =
+  convert(C, convert(GeocentricLatLon{Datum}, coords))
 
-Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} = convert(GeocentricLatLonAlt{Datum}, convert(GeocentricLatLon{Datum}, coords))
+Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} =
+  convert(GeocentricLatLonAlt{Datum}, convert(GeocentricLatLon{Datum}, coords))
 
-Base.convert(::Type{C}, coords::LatLonAlt{Datum}) where {Datum,C<:Projected{Datum}} = convert(C, convert(LatLon{Datum}, coords))
+Base.convert(::Type{C}, coords::LatLonAlt{Datum}) where {Datum,C<:Projected{Datum}} =
+  convert(C, convert(LatLon{Datum}, coords))
 
-Base.convert(::Type{LatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} = convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
+Base.convert(::Type{LatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} =
+  convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
 
 function Base.convert(::Type{C}, coords::LatLon{Datum}) where {Datum,C<:Projected{Datum}}
   S = projshift(C)

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -115,6 +115,7 @@ include("projected/transversemercator.jl")
 # ----------
 # FALLBACKS
 # ----------
+
 function Base.convert(::Type{C}, coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}}
   convert(C, convert(LatLon{Datum}, coords))
 end

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -128,7 +128,6 @@ Base.convert(::Type{C}, coords::LatLonAlt{Datum}) where {Datum,C<:Projected{Datu
 
 Base.convert(::Type{LatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} = convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
 
-
 function Base.convert(::Type{C}, coords::LatLon{Datum}) where {Datum,C<:Projected{Datum}}
   S = projshift(C)
   T = numtype(coords.lon)

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -116,29 +116,18 @@ include("projected/transversemercator.jl")
 # FALLBACKS
 # ----------
 
-function Base.convert(::Type{C}, coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}}
-  convert(C, convert(LatLon{Datum}, coords))
-end
+Base.convert(::Type{C}, coords::GeocentricLatLon{Datum}) where {Datum,C<:Projected{Datum}} = convert(C, convert(LatLon{Datum}, coords))
 
-function Base.convert(::Type{GeocentricLatLon{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
-  convert(GeocentricLatLon{Datum}, convert(LatLon{Datum}, coords))
-end
+Base.convert(::Type{GeocentricLatLon{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} = convert(GeocentricLatLon{Datum}, convert(LatLon{Datum}, coords))
 
-function Base.convert(::Type{C}, coords::GeocentricLatLonAlt{Datum}) where {Datum,C<:Projected{Datum}}
-  convert(C, convert(GeocentricLatLon{Datum}, coords))
-end
+Base.convert(::Type{C}, coords::GeocentricLatLonAlt{Datum}) where {Datum,C<:Projected{Datum}} = convert(C, convert(GeocentricLatLon{Datum}, coords))
 
-function Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
-  convert(GeocentricLatLonAlt{Datum}, convert(GeocentricLatLon{Datum}, coords))
-end
+Base.convert(::Type{GeocentricLatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} = convert(GeocentricLatLonAlt{Datum}, convert(GeocentricLatLon{Datum}, coords))
 
-function Base.convert(::Type{C}, coords::LatLonAlt{Datum}) where {Datum,C<:Projected{Datum}}
-  convert(C, convert(LatLon{Datum}, coords))
-end
+Base.convert(::Type{C}, coords::LatLonAlt{Datum}) where {Datum,C<:Projected{Datum}} = convert(C, convert(LatLon{Datum}, coords))
 
-function Base.convert(::Type{LatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}}
-  convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
-end
+Base.convert(::Type{LatLonAlt{Datum}}, coords::C) where {Datum,C<:Projected{Datum}} = convert(LatLonAlt{Datum}, convert(LatLon{Datum}, coords))
+
 
 function Base.convert(::Type{C}, coords::LatLon{Datum}) where {Datum,C<:Projected{Datum}}
   S = projshift(C)

--- a/src/shift.jl
+++ b/src/shift.jl
@@ -22,7 +22,7 @@ Shift(; lonₒ=0.0°, xₒ=0.0m, yₒ=0.0m) = Shift(asdeg(lonₒ), asmet(xₒ), 
 Shifts the `CRS` with given longitude origin `lonₒ` in degrees, false easting `xₒ`
 and false northing `yₒ` in meters.
 """
-shift(CRS::Type{<:Projected}; lonₒ=0.0°, xₒ=0.0m, yₒ=0.0m) = CRS{Shift(; lonₒ, xₒ, yₒ)}
+shift(CRS::Type{<:Projected}; lonₒ=0.0°, xₒ=0.0m, yₒ=0.0m) = CRS{Shift(;lonₒ,xₒ,yₒ)}
 
 """
     CoordRefSystems.shift(Datum, epoch)

--- a/src/transforms/utils.jl
+++ b/src/transforms/utils.jl
@@ -83,7 +83,7 @@ between `Datum₁`, `Datum₂`, ..., `Datumₙ`.
 See also [`Sequential`](@ref).
 """
 macro sequential(Datums...)
-  transforms = map(1:(length(Datums) - 1)) do i
+  transforms = map(1:(length(Datums)-1)) do i
     :(transform($(Datums[i]), $(Datums[i + 1])))
   end
   expr = :(Sequential($(transforms...)))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/test/crs/constructors.jl
+++ b/test/crs/constructors.jl
@@ -262,7 +262,6 @@
       @test_throws ArgumentError GeocentricLatLon(T(1) * °, T(1) * s)
       @test_throws ArgumentError GeocentricLatLon(T(1) * s, T(1) * s)
     end
-    # Add Test for GeocentricLatLonAlt
     @testset "GeocentricLatLonAlt" begin
       @test GeocentricLatLonAlt(T(1), T(2), T(3)) == GeocentricLatLonAlt(T(1) * °, T(2) * °, T(3) * m)
       @test GeocentricLatLonAlt(T(1) * °, 2 * °, T(3) * m) == GeocentricLatLonAlt(T(1) * °, T(2) * °, T(3) * m)

--- a/test/crs/constructors.jl
+++ b/test/crs/constructors.jl
@@ -262,6 +262,7 @@
       @test_throws ArgumentError GeocentricLatLon(T(1) * °, T(1) * s)
       @test_throws ArgumentError GeocentricLatLon(T(1) * s, T(1) * s)
     end
+
     @testset "GeocentricLatLonAlt" begin
       @test GeocentricLatLonAlt(T(1), T(2), T(3)) == GeocentricLatLonAlt(T(1) * °, T(2) * °, T(3) * m)
       @test GeocentricLatLonAlt(T(1) * °, 2 * °, T(3) * m) == GeocentricLatLonAlt(T(1) * °, T(2) * °, T(3) * m)

--- a/test/crs/constructors.jl
+++ b/test/crs/constructors.jl
@@ -264,7 +264,6 @@
     end
     # Add Test for GeocentricLatLonAlt
     @testset "GeocentricLatLonAlt" begin
-
     end
 
     @testset "AuthalicLatLon" begin

--- a/test/crs/constructors.jl
+++ b/test/crs/constructors.jl
@@ -262,6 +262,10 @@
       @test_throws ArgumentError GeocentricLatLon(T(1) * °, T(1) * s)
       @test_throws ArgumentError GeocentricLatLon(T(1) * s, T(1) * s)
     end
+    # Add Test for GeocentricLatLonAlt
+    @testset "GeocentricLatLonAlt" begin
+
+    end
 
     @testset "AuthalicLatLon" begin
       @test AuthalicLatLon(T(1), T(2)) == AuthalicLatLon(T(1) * °, T(2) * °)

--- a/test/crs/constructors.jl
+++ b/test/crs/constructors.jl
@@ -264,6 +264,34 @@
     end
     # Add Test for GeocentricLatLonAlt
     @testset "GeocentricLatLonAlt" begin
+      @test GeocentricLatLonAlt(T(1), T(2), T(3)) == GeocentricLatLonAlt(T(1) * °, T(2) * °, T(3) * m)
+      @test GeocentricLatLonAlt(T(1) * °, 2 * °, T(3) * m) == GeocentricLatLonAlt(T(1) * °, T(2) * °, T(3) * m)
+      @test allapprox(
+        GeocentricLatLonAlt(T(π / 4) * rad, T(π / 4) * rad, T(1) * km),
+        GeocentricLatLonAlt(T(45) * °, T(45) * °, T(1000) * m)
+      )
+
+      c = GeocentricLatLonAlt(T(1), T(2), T(3))
+      @test sprint(show, c) == "GeocentricLatLonAlt{WGS84Latest}(lat: 1.0°, lon: 2.0°, alt: 3.0 m)"
+      if T === Float32
+        @test sprint(show, MIME("text/plain"), c) == """
+        GeocentricLatLonAlt{WGS84Latest} coordinates
+        ├─ lat: 1.0f0°
+        ├─ lon: 2.0f0°
+        └─ alt: 3.0f0 m"""
+      else
+        @test sprint(show, MIME("text/plain"), c) == """
+        GeocentricLatLonAlt{WGS84Latest} coordinates
+        ├─ lat: 1.0°
+        ├─ lon: 2.0°
+        └─ alt: 3.0 m"""
+      end
+
+      # error: invalid units for coordinates
+      @test_throws ArgumentError GeocentricLatLonAlt(T(1), T(1) * °, T(1) * m)
+      @test_throws ArgumentError GeocentricLatLonAlt(T(1) * s, T(1) * °, T(1) * m)
+      @test_throws ArgumentError GeocentricLatLonAlt(T(1) * °, T(1) * s, T(1) * m)
+      @test_throws ArgumentError GeocentricLatLonAlt(T(1) * °, T(1) * °, T(1) * s)
     end
 
     @testset "AuthalicLatLon" begin

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -352,9 +352,7 @@
 
     # conversion LatLonAlt <> GeocentricLatLonAlt is tested in the next section
     @testset "LatLonAlt <> GeocentricLatLonAlt" begin
-
     end
-
 
     if T === Float64
       # altitude can only be calculated accurately using Float64
@@ -407,7 +405,6 @@
 
       # conversion GeocentricLatLonAlt <> Cartesian is tested in the next section
       @testset "GeocentricLatLonAlt <> Cartesian" begin
-
       end
     end
 

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -352,6 +352,17 @@
 
     # conversion LatLonAlt <> GeocentricLatLonAlt is tested in the next section
     @testset "LatLonAlt <> GeocentricLatLonAlt" begin
+      c1 = LatLonAlt(T(30), T(40), T(0))
+      c2 = convert(GeocentricLatLonAlt, c1)
+      @test allapprox(c2, GeocentricLatLonAlt(T(29.833635809829065), T(40), T(0)))
+      c3 = convert(LatLonAlt, c2)
+      @test allapprox(c3, c1)
+
+      # type stability
+      c1 = LatLonAlt(T(30), T(40), T(0))
+      c2 = GeocentricLatLonAlt(T(29.833635809829065), T(40), T(0))
+      @inferred convert(GeocentricLatLonAlt, c1)
+      @inferred convert(LatLonAlt, c2)
     end
 
     if T === Float64
@@ -405,6 +416,47 @@
 
       # conversion GeocentricLatLonAlt <> Cartesian is tested in the next section
       @testset "GeocentricLatLonAlt <> Cartesian" begin
+        c1 = GeocentricLatLonAlt(T(30), T(40), T(0))
+        c2 = convert(Cartesian, c1)
+        @test allapprox(c2, Cartesian{WGS84Latest}(T(4227784.905275363), T(3547532.754713428), T(3186385.300568595)))
+        c3 = convert(GeocentricLatLonAlt, c2)
+        @test allapprox(c3, c1)
+
+        c1 = GeocentricLatLonAlt(T(35), T(45), T(100))
+        c2 = convert(Cartesian, c1)
+        @test allapprox(c2, Cartesian{WGS84Latest}(T(3690364.254026674), T(3690364.2540266733), T(3654357.744678035)))
+        c3 = convert(GeocentricLatLonAlt, c2)
+        @test allapprox(c3, c1)
+
+        c1 = GeocentricLatLonAlt(T(40), T(50), T(200))
+        c2 = convert(Cartesian, c1)
+        @test allapprox(c2, Cartesian{WGS84Latest}(T(3136354.020667129), T(3737761.1717773457), T(4094220.2645078264)))
+        c3 = convert(GeocentricLatLonAlt, c2)
+        @test allapprox(c3, c1)
+
+        c1 = GeocentricLatLonAlt(-T(30), -T(40), T(0))
+        c2 = convert(Cartesian, c1)
+        @test allapprox(c2, Cartesian{WGS84Latest}(T(4227784.905275363), -T(3547532.754713428), -T(3186385.300568595)))
+        c3 = convert(GeocentricLatLonAlt, c2)
+        @test allapprox(c3, c1)
+
+        c1 = GeocentricLatLonAlt(-T(35), T(45), T(100))
+        c2 = convert(Cartesian, c1)
+        @test allapprox(c2, Cartesian{WGS84Latest}(T(3690364.254026674), T(3690364.2540266733), -T(3654357.744678035)))
+        c3 = convert(GeocentricLatLonAlt, c2)
+        @test allapprox(c3, c1)
+
+        c1 = GeocentricLatLonAlt(T(40), -T(50), T(200))
+        c2 = convert(Cartesian, c1)
+        @test allapprox(c2,Cartesian{WGS84Latest}(T(3136354.020667129), -T(3737761.1717773457), T(4094220.2645078264)))
+        c3 = convert(GeocentricLatLonAlt, c2)
+        @test allapprox(c3, c1)
+
+        # type stability
+        c1 = GeocentricLatLonAlt(T(30), T(40), T(0))
+        c2 = Cartesian{WGS84Latest}(T(4227784.905275363), T(3547532.754713428), T(3186385.300568595))
+        @inferred convert(Cartesian, c1)
+        @inferred convert(LatLonAlt, c2)
       end
     end
 

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -446,7 +446,7 @@
 
         c1 = GeocentricLatLonAlt(T(40), -T(50), T(200))
         c2 = convert(Cartesian, c1)
-        @test allapprox(c2,Cartesian{WGS84Latest}(T(3136354.020667129), -T(3737761.1717773457), T(4094220.2645078264)))
+        @test allapprox(c2, Cartesian{WGS84Latest}(T(3136354.020667129), -T(3737761.1717773457), T(4094220.2645078264)))
         c3 = convert(GeocentricLatLonAlt, c2)
         @test allapprox(c3, c1)
 

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -204,7 +204,7 @@
   end
 
   @testset "Geographic" begin
-    @testset "GeodeticLatLon <> GeocentricLatLon" begin
+    @testset "LatLon <> GeocentricLatLon" begin
       c1 = LatLon(T(30), T(40))
       c2 = convert(GeocentricLatLon, c1)
       @test allapprox(c2, GeocentricLatLon(T(29.833635809829065), T(40)))
@@ -248,7 +248,7 @@
       @inferred convert(LatLon, c2)
     end
 
-    @testset "GeodeticLatLon <> AuthalicLatLon" begin
+    @testset "LatLon <> AuthalicLatLon" begin
       c1 = LatLon(T(30), T(40))
       c2 = convert(AuthalicLatLon, c1)
       @test allapprox(c2, AuthalicLatLon(T(29.888997034459567), T(40)))
@@ -290,6 +290,34 @@
       c2 = AuthalicLatLon(T(29.888997034459567), T(40))
       @inferred convert(AuthalicLatLon, c1)
       @inferred convert(LatLon, c2)
+    end
+
+    @testset "LatLon <> LatLonAlt" begin
+      c1 = LatLon(T(30), T(40))
+      c2 = convert(LatLonAlt, c1)
+      @test allapprox(c2, LatLonAlt(T(30), T(40), T(0)))
+      c3 = convert(LatLon, c2)
+      @test allapprox(c3, c1)
+
+      # type stability
+      c1 = LatLon(T(30), T(40))
+      c2 = LatLonAlt(T(30), T(40), T(0))
+      @inferred convert(LatLonAlt, c1)
+      @inferred convert(LatLon, c2)
+    end
+
+    @testset "LatLonAlt <> GeocentricLatLonAlt" begin
+      c1 = LatLonAlt(T(30), T(40), T(0))
+      c2 = convert(GeocentricLatLonAlt, c1)
+      @test allapprox(c2, GeocentricLatLonAlt(T(29.833635809829065), T(40), T(0)))
+      c3 = convert(LatLonAlt, c2)
+      @test allapprox(c3, c1)
+
+      # type stability
+      c1 = LatLonAlt(T(30), T(40), T(0))
+      c2 = GeocentricLatLonAlt(T(29.833635809829065), T(40), T(0))
+      @inferred convert(GeocentricLatLonAlt, c1)
+      @inferred convert(LatLonAlt, c2)
     end
 
     @testset "LatLon <> Cartesian" begin
@@ -334,34 +362,6 @@
       c2 = Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
       @inferred convert(Cartesian, c1)
       @inferred convert(LatLon, c2)
-    end
-
-    @testset "LatLon <> LatLonAlt" begin
-      c1 = LatLon(T(30), T(40))
-      c2 = convert(LatLonAlt, c1)
-      @test allapprox(c2, LatLonAlt(T(30), T(40), T(0)))
-      c3 = convert(LatLon, c2)
-      @test allapprox(c3, c1)
-
-      # type stability
-      c1 = LatLon(T(30), T(40))
-      c2 = LatLonAlt(T(30), T(40), T(0))
-      @inferred convert(LatLonAlt, c1)
-      @inferred convert(LatLon, c2)
-    end
-
-    @testset "LatLonAlt <> GeocentricLatLonAlt" begin
-      c1 = LatLonAlt(T(30), T(40), T(0))
-      c2 = convert(GeocentricLatLonAlt, c1)
-      @test allapprox(c2, GeocentricLatLonAlt(T(29.833635809829065), T(40), T(0)))
-      c3 = convert(LatLonAlt, c2)
-      @test allapprox(c3, c1)
-
-      # type stability
-      c1 = LatLonAlt(T(30), T(40), T(0))
-      c2 = GeocentricLatLonAlt(T(29.833635809829065), T(40), T(0))
-      @inferred convert(GeocentricLatLonAlt, c1)
-      @inferred convert(LatLonAlt, c2)
     end
 
     if T === Float64
@@ -864,6 +864,18 @@
       @inferred convert(LatLon{ITRF{2008}}, c3)
       @inferred convert(LatLon{WGS84{2296}}, c4)
       @inferred convert(LatLon{WGS84{0}}, c5)
+    end
+
+    @testset "LatLonAlt: Datum conversion" begin
+      # TODO
+    end
+
+    @testset "GeocentricLatLon: Datum conversion" begin
+      # TODO
+    end
+
+    @testset "GeocentricLatLonAlt: Datum conversion" begin
+      # TODO
     end
   end
 
@@ -1452,7 +1464,7 @@
       @inferred convert(Cartesian3D, c6)
     end
 
-    @testset "Projection conversion" begin
+    @testset "Projected <> Projected" begin
       ShiftedMercator = CoordRefSystems.shift(Mercator{WGS84Latest}, lonₒ=15.0°, xₒ=200.0m, yₒ=200.0m)
 
       # same datum

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -350,7 +350,6 @@
       @inferred convert(LatLon, c2)
     end
 
-    # conversion LatLonAlt <> GeocentricLatLonAlt is tested in the next section
     @testset "LatLonAlt <> GeocentricLatLonAlt" begin
       c1 = LatLonAlt(T(30), T(40), T(0))
       c2 = convert(GeocentricLatLonAlt, c1)
@@ -414,7 +413,6 @@
         @inferred convert(LatLonAlt, c2)
       end
 
-      # conversion GeocentricLatLonAlt <> Cartesian is tested in the next section
       @testset "GeocentricLatLonAlt <> Cartesian" begin
         c1 = GeocentricLatLonAlt(T(30), T(40), T(0))
         c2 = convert(Cartesian, c1)

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -350,6 +350,12 @@
       @inferred convert(LatLon, c2)
     end
 
+    # conversion LatLonAlt <> GeocentricLatLonAlt is tested in the next section
+    @testset "LatLonAlt <> GeocentricLatLonAlt" begin
+
+    end
+
+
     if T === Float64
       # altitude can only be calculated accurately using Float64
       @testset "LatLonAlt <> Cartesian" begin
@@ -397,6 +403,11 @@
         c2 = Cartesian{WGS84Latest}(T(4234890.278665873), T(3553494.8709047823), T(3170373.735383637))
         @inferred convert(Cartesian, c1)
         @inferred convert(LatLonAlt, c2)
+      end
+
+      # conversion GeocentricLatLonAlt <> Cartesian is tested in the next section
+      @testset "GeocentricLatLonAlt <> Cartesian" begin
+
       end
     end
 

--- a/test/crs/crsapi.jl
+++ b/test/crs/crsapi.jl
@@ -16,7 +16,6 @@
     @test datum(c) === WGS84Latest
     c = AuthalicLatLon(T(1), T(1))
     @test datum(c) === WGS84Latest
-
   end
 
   @testset "ncoords" begin

--- a/test/crs/crsapi.jl
+++ b/test/crs/crsapi.jl
@@ -16,6 +16,7 @@
     @test datum(c) === WGS84Latest
     c = AuthalicLatLon(T(1), T(1))
     @test datum(c) === WGS84Latest
+
   end
 
   @testset "ncoords" begin
@@ -34,6 +35,10 @@
     c = LatLon(T(30), T(60))
     @test CoordRefSystems.ncoords(c) == 2
     c = LatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.ncoords(c) == 3
+    c = GeocentricLatLon(T(30), T(60))
+    @test CoordRefSystems.ncoords(c) == 2
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
     @test CoordRefSystems.ncoords(c) == 3
     c = Mercator(T(1), T(1))
     @test CoordRefSystems.ncoords(c) == 2
@@ -58,6 +63,10 @@
     @test CoordRefSystems.ndims(c) == 3
     c = LatLonAlt(T(30), T(60), T(1))
     @test CoordRefSystems.ndims(c) == 3
+    c = GeocentricLatLon(T(30), T(60))
+    @test CoordRefSystems.ndims(c) == 3
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.ndims(c) == 3
     c = Mercator(T(1), T(1))
     @test CoordRefSystems.ndims(c) == 2
     c = ShiftedMercator(T(1), T(2))
@@ -79,6 +88,10 @@
     @test CoordRefSystems.names(c) == (:lat, :lon)
     c = LatLonAlt(T(30), T(60), T(1))
     @test CoordRefSystems.names(c) == (:lat, :lon, :alt)
+    c = GeocentricLatLon(T(30), T(60))
+    @test CoordRefSystems.names(c) == (:lat, :lon)
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.names(c) == (:lat, :lon, :alt)
     c = Mercator(T(1), T(1))
     @test CoordRefSystems.names(c) == (:x, :y)
     c = ShiftedMercator(T(1), T(2))
@@ -99,6 +112,10 @@
     c = LatLon(T(30), T(60))
     @test CoordRefSystems.values(c) == (T(30) * °, T(60) * °)
     c = LatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.values(c) == (T(30) * °, T(60) * °, T(1) * m)
+    c = GeocentricLatLon(T(30), T(60))
+    @test CoordRefSystems.values(c) == (T(30) * °, T(60) * °)
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
     @test CoordRefSystems.values(c) == (T(30) * °, T(60) * °, T(1) * m)
     c = Mercator(T(1), T(2))
     @test CoordRefSystems.values(c) == (T(1) * m, T(2) * m)
@@ -123,6 +140,8 @@
     @test CoordRefSystems.raw(c) == (T(60), T(30), T(1))
     c = GeocentricLatLon(T(30), T(60))
     @test CoordRefSystems.raw(c) == (T(60), T(30))
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.raw(c) == (T(60), T(30), T(1))
     c = AuthalicLatLon(T(30), T(60))
     @test CoordRefSystems.raw(c) == (T(60), T(30))
     c = Mercator(T(1), T(2))
@@ -205,6 +224,8 @@
     @test CoordRefSystems.constructor(c) === LatLonAlt{WGS84Latest}
     c = GeocentricLatLon(T(30), T(60))
     @test CoordRefSystems.constructor(c) === GeocentricLatLon{WGS84Latest}
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.constructor(c) === GeocentricLatLonAlt{WGS84Latest}
     c = AuthalicLatLon(T(30), T(60))
     @test CoordRefSystems.constructor(c) === AuthalicLatLon{WGS84Latest}
     c = Mercator(T(1), T(1))
@@ -252,6 +273,9 @@
     rv = CoordRefSystems.raw(c)
     @test CoordRefSystems.reconstruct(typeof(c), rv) == c
     c = GeocentricLatLon(T(30), T(60))
+    rv = CoordRefSystems.raw(c)
+    @test CoordRefSystems.reconstruct(typeof(c), rv) == c
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
     rv = CoordRefSystems.raw(c)
     @test CoordRefSystems.reconstruct(typeof(c), rv) == c
     c = AuthalicLatLon(T(30), T(60))
@@ -304,6 +328,8 @@
     @test CoordRefSystems.lentype(c) == typeof(T(1) * m)
     c = GeocentricLatLon(T(30), T(60))
     @test CoordRefSystems.lentype(c) == typeof(T(1) * m)
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.lentype(c) == typeof(T(1) * m)
     c = AuthalicLatLon(T(30), T(60))
     @test CoordRefSystems.lentype(c) == typeof(T(1) * m)
     c = Mercator(T(1), T(1))
@@ -343,6 +369,8 @@
     @test CoordRefSystems.mactype(c) == T
     c = GeocentricLatLon(T(30), T(60))
     @test CoordRefSystems.mactype(c) == T
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.mactype(c) == T
     c = AuthalicLatLon(T(30), T(60))
     @test CoordRefSystems.mactype(c) == T
     c = Mercator(T(1), T(1))
@@ -376,6 +404,7 @@
     equaltest(LatLon)
     equaltest(LatLonAlt)
     equaltest(GeocentricLatLon)
+    equaltest(GeocentricLatLonAlt)
     equaltest(AuthalicLatLon)
     equaltest(Mercator)
     equaltest(WebMercator)
@@ -397,6 +426,8 @@
     isapproxtest3D(Spherical)
     isapproxtest3D(LatLon)
     isapproxtest3D(LatLonAlt)
+    isapproxtest3D(GeocentricLatLon)
+    isapproxtest3D(GeocentricLatLonAlt)
     isapproxtest3D(Mercator)
     isapproxtest3D(WebMercator)
     isapproxtest3D(PlateCarree)
@@ -419,6 +450,10 @@
     tol = CoordRefSystems.atol(T) * m
     c = LatLon(T(1), T(1))
     @test CoordRefSystems.tol(c) == tol
+    c = LatLonAlt(T(1), T(1), T(1))
+    @test CoordRefSystems.tol(c) == tol
+    c = GeocentricLatLon(T(1), T(1))
+    @test CoordRefSystems.tol(c) == tol
     c = Cartesian(T(1), T(1))
     @test CoordRefSystems.tol(c) == tol
     c = Polar(T(1), 1.0f0)
@@ -439,6 +474,11 @@
     c2 = LatLon(45.0f0, 90.0f0)
     @test typeof(convert(C, c1)) === C
     @test typeof(convert(C, c2)) === C
+    c1 = GeocentricLatLon(45.0, 90.0)
+    c2 = GeocentricLatLon(45.0f0, 90.0f0)
+    @test typeof(convert(C, c1)) === C
+    @test typeof(convert(C, c2)) === C
+
     C = typeof(PlateCarree(T(0), T(0)))
     c1 = Cartesian(1.0, 1.0)
     c2 = Cartesian(1.0f0, 1.0f0)
@@ -462,6 +502,8 @@
     @test convert(Cartesian, c) === c
     c = LatLon(T(45), T(90))
     @test convert(LatLon, c) === c
+    c = GeocentricLatLon(T(45), T(90))
+    @test convert(GeocentricLatLon, c) === c
     c = OrthoNorth(T(1), T(1))
     @test convert(OrthoNorth, c) === c
 
@@ -478,5 +520,9 @@
     @inferred convert(C, c1)
     @inferred convert(C, c2)
     @inferred convert(Cartesian, c3)
+    c1 = GeocentricLatLon(45.0, 90.0)
+    c2 = GeocentricLatLon(45.0f0, 90.0f0)
+    @inferred convert(C, c1)
+    @inferred convert(C, c2)
   end
 end

--- a/test/crs/crsapi.jl
+++ b/test/crs/crsapi.jl
@@ -8,6 +8,14 @@
     @test datum(c) === NoDatum
     c = LatLon(T(1), T(1))
     @test datum(c) === WGS84Latest
+    c = LatLonAlt(T(1), T(1), T(1))
+    @test datum(c) === WGS84Latest
+    c = GeocentricLatLon(T(1), T(1))
+    @test datum(c) === WGS84Latest
+    c = GeocentricLatLonAlt(T(1), T(1), T(1))
+    @test datum(c) === WGS84Latest
+    c = AuthalicLatLon(T(1), T(1))
+    @test datum(c) === WGS84Latest
   end
 
   @testset "ncoords" begin
@@ -156,6 +164,8 @@
     @test CoordRefSystems.units(c) == (°, °, m)
     c = GeocentricLatLon(T(30), T(60))
     @test CoordRefSystems.units(c) == (°, °)
+    c = GeocentricLatLonAlt(T(30), T(60), T(1))
+    @test CoordRefSystems.units(c) == (°, °, m)
     c = AuthalicLatLon(T(30), T(60))
     @test CoordRefSystems.units(c) == (°, °)
     c = Mercator(T(1), T(1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,13 +4,14 @@ using StableRNGs
 using ArchGDAL
 using ArchGDAL.GDAL
 using Test
+using Random # used for testing sort
 
 using CoordRefSystems: Met, Deg, Rad
 using Unitful: m, mm, cm, km, rad, °, s
 
 include("testutils.jl")
 
-testfiles = ["ellipsoids.jl", "datums.jl", "crs.jl", "promotion.jl", "strings.jl", "get.jl", "misc.jl"]
+testfiles = ["ellipsoids.jl", "datums.jl", "crs.jl", "promotion.jl", "strings.jl", "get.jl", "misc.jl","sorting.jl"]
 
 # --------------------------------
 # RUN TESTS WITH SINGLE PRECISION

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ using Unitful: m, mm, cm, km, rad, °, s
 
 include("testutils.jl")
 
-testfiles = ["ellipsoids.jl", "datums.jl", "crs.jl", "promotion.jl", "strings.jl", "get.jl", "misc.jl","sorting.jl"]
+testfiles = ["ellipsoids.jl", "datums.jl", "crs.jl", "promotion.jl", "strings.jl", "get.jl", "misc.jl", "sorting.jl"]
 
 # --------------------------------
 # RUN TESTS WITH SINGLE PRECISION

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -50,7 +50,10 @@ end
   _lon= -180:10:180
   _alt= 0:10:100
   sorted_latlon = [LatLon(lat, lon) for lon in _lon,lat in _lat][:]
+  sorted_lonlat = [LatLon(lat, lon) for lat in _lat,lon in _lon][:]
   sorted_latlonalt = [LatLonAlt(lat, lon, alt) for  alt in _alt,lon in _lon,lat in _lat ][:]
+  sorted_altlonlat = [LatLonAlt(lat, lon, alt) for  lat in _lat,lon in _lon,alt in _alt ][:]
+  sorted_altlatlon = [LatLonAlt(lat, lon, alt) for  lon in _lon,lat in _lat,alt in _alt ][:]
   sorted_geocentriclatlon = [GeocentricLatLon(lat, lon) for lon in _lon, lat in _lat][:]
   sorted_geocentriclatlonalt = [GeocentricLatLonAlt(lat, lon, alt) for alt in _alt, lon in _lon, lat in _lat  ][:]
   shuffled_latlon = sorted_latlon[randperm(length(sorted_latlon))]
@@ -62,5 +65,16 @@ end
   @test sort(shuffled_latlonalt) == sorted_latlonalt
   @test sort(shuffled_geocentriclatlon) == sorted_geocentriclatlon
   @test sort(shuffled_geocentriclatlonalt) == sorted_geocentriclatlonalt
+
+  @test sort_by_field(shuffled_latlon, :lon) == sorted_lonlat
+  @test sort_by_field(shuffled_latlonalt, [:alt,:lon,:lat]) == sorted_altlonlat
+  @test sort_by_field(shuffled_latlonalt, :alt) == sorted_altlatlon
+
+  @test sort_by_field(shuffled_latlon, "lon") == sorted_lonlat
+  @test sort_by_field(shuffled_latlonalt, ["alt","lon","lat"]) == sorted_altlonlat
+  @test sort_by_field(shuffled_latlonalt, "alt") == sorted_altlatlon
+
+  @test sort_by_field!(shuffled_latlon, :lon) == sorted_lonlat
+  @test sort_by_field!(shuffled_latlonalt, [:alt,:lon,:lat]) == sorted_altlonlat
 
 end

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -1,0 +1,66 @@
+@testset "Comparison between Geographic Coordinates" begin
+  coord_latlon = LatLon{WGS84}(45, 45)
+  coord_latlon_greater_lat = LatLon{WGS84}(46, 44)
+  coord_latlon_greater_lon = LatLon{WGS84}(45, 46)
+  coord_latlon_lower_lat = LatLon{WGS84}(44, 46)
+  coord_latlon_lower_lon = LatLon{WGS84}(45, 44)
+  coord_latlonalt = LatLonAlt{WGS84}(45, 45, 10)
+  coord_latlonalt_greater_lat = LatLonAlt{WGS84}(46, 44, 10)
+  coord_latlonalt_greater_lon = LatLonAlt{WGS84}(45, 46, 10)
+  coord_latlonalt_greater_alt = LatLonAlt{WGS84}(45, 45, 11)
+  coord_latlonalt_lower_lat = LatLonAlt{WGS84}(44, 46, 10)
+  coord_latlonalt_lower_lon = LatLonAlt{WGS84}(45, 44, 10)
+  coord_latlonalt_lower_alt = LatLonAlt{WGS84}(45, 45, 9)
+  coord_geocentriclatlon = GeocentricLatLon{WGS84}(45, 45)
+  coord_geocentriclatlon_greater_lat = GeocentricLatLon{WGS84}(46, 44)
+  coord_geocentriclatlon_greater_lon = GeocentricLatLon{WGS84}(45, 46)
+  coord_geocentriclatlon_lower_lat = GeocentricLatLon{WGS84}(44, 46)
+  coord_geocentriclatlon_lower_lon = GeocentricLatLon{WGS84}(45, 44)
+  coord_geocentriclatlonalt = GeocentricLatLonAlt{WGS84}(45, 45, 10)
+  coord_geocentriclatlonalt_greater_lat = GeocentricLatLonAlt{WGS84}(46, 44, 10)
+  coord_geocentriclatlonalt_greater_lon = GeocentricLatLonAlt{WGS84}(45, 46, 10)
+  coord_geocentriclatlonalt_greater_alt = GeocentricLatLonAlt{WGS84}(45, 45, 11)
+  coord_geocentriclatlonalt_lower_lat = GeocentricLatLonAlt{WGS84}(44, 46, 10)
+  coord_geocentriclatlonalt_lower_lon = GeocentricLatLonAlt{WGS84}(45, 44, 10)
+  coord_geocentriclatlonalt_lower_alt = GeocentricLatLonAlt{WGS84}(45, 45, 9)
+
+  coord_latlon_datum = LatLon{WGS84{1796}}(45, 45)
+
+  @test coord_latlon < coord_latlon_greater_lat
+  @test coord_latlon < coord_latlon_greater_lon
+  @test coord_latlon > coord_latlon_lower_lat
+  @test coord_latlon > coord_latlon_lower_lon
+  @test coord_latlonalt < coord_latlonalt_greater_lat
+  @test coord_latlonalt < coord_latlonalt_greater_lon
+  @test coord_latlonalt < coord_latlonalt_greater_alt
+  @test coord_latlonalt > coord_latlonalt_lower_lat
+  @test coord_latlonalt > coord_latlonalt_lower_lon
+  @test coord_latlonalt > coord_latlonalt_lower_alt
+  @test coord_geocentriclatlon < coord_geocentriclatlon_greater_lat
+  @test coord_geocentriclatlon < coord_geocentriclatlon_greater_lon
+  @test coord_geocentriclatlon > coord_geocentriclatlon_lower_lat
+  @test coord_geocentriclatlon > coord_geocentriclatlon_lower_lon
+  @test coord_geocentriclatlonalt < coord_geocentriclatlonalt_greater_lat
+  # throw error if different datums
+  @test_throws MethodError coord_latlon < coord_latlon_datum
+end
+
+@testset "Sort Coordinates" begin
+  _lat= -90:10:90
+  _lon= -180:10:180
+  _alt= 0:10:100
+  sorted_latlon = [LatLon(lat, lon) for lon in _lon,lat in _lat][:]
+  sorted_latlonalt = [LatLonAlt(lat, lon, alt) for  alt in _alt,lon in _lon,lat in _lat ][:]
+  sorted_geocentriclatlon = [GeocentricLatLon(lat, lon) for lon in _lon, lat in _lat][:]
+  sorted_geocentriclatlonalt = [GeocentricLatLonAlt(lat, lon, alt) for alt in _alt, lon in _lon, lat in _lat  ][:]
+  shuffled_latlon = sorted_latlon[randperm(length(sorted_latlon))]
+  shuffled_latlonalt = sorted_latlonalt[randperm(length(sorted_latlonalt))]
+  shuffled_geocentriclatlon = sorted_geocentriclatlon[randperm(length(sorted_geocentriclatlon))]
+  shuffled_geocentriclatlonalt = sorted_geocentriclatlonalt[randperm(length(sorted_geocentriclatlonalt))]
+
+  @test sort(shuffled_latlon) == sorted_latlon
+  @test sort(shuffled_latlonalt) == sorted_latlonalt
+  @test sort(shuffled_geocentriclatlon) == sorted_geocentriclatlon
+  @test sort(shuffled_geocentriclatlonalt) == sorted_geocentriclatlonalt
+
+end

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -46,16 +46,16 @@
 end
 
 @testset "Sort Coordinates" begin
-  _lat= -90:10:90
-  _lon= -180:10:180
-  _alt= 0:10:100
-  sorted_latlon = [LatLon(lat, lon) for lon in _lon,lat in _lat][:]
-  sorted_lonlat = [LatLon(lat, lon) for lat in _lat,lon in _lon][:]
-  sorted_latlonalt = [LatLonAlt(lat, lon, alt) for  alt in _alt,lon in _lon,lat in _lat ][:]
-  sorted_altlonlat = [LatLonAlt(lat, lon, alt) for  lat in _lat,lon in _lon,alt in _alt ][:]
-  sorted_altlatlon = [LatLonAlt(lat, lon, alt) for  lon in _lon,lat in _lat,alt in _alt ][:]
+  _lat = -90:10:90
+  _lon = -180:10:180
+  _alt = 0:10:100
+  sorted_latlon = [LatLon(lat, lon) for lon in _lon, lat in _lat][:]
+  sorted_lonlat = [LatLon(lat, lon) for lat in _lat, lon in _lon][:]
+  sorted_latlonalt = [LatLonAlt(lat, lon, alt) for alt in _alt, lon in _lon, lat in _lat][:]
+  sorted_altlonlat = [LatLonAlt(lat, lon, alt) for lat in _lat, lon in _lon, alt in _alt][:]
+  sorted_altlatlon = [LatLonAlt(lat, lon, alt) for lon in _lon, lat in _lat, alt in _alt][:]
   sorted_geocentriclatlon = [GeocentricLatLon(lat, lon) for lon in _lon, lat in _lat][:]
-  sorted_geocentriclatlonalt = [GeocentricLatLonAlt(lat, lon, alt) for alt in _alt, lon in _lon, lat in _lat  ][:]
+  sorted_geocentriclatlonalt = [GeocentricLatLonAlt(lat, lon, alt) for alt in _alt, lon in _lon, lat in _lat][:]
   shuffled_latlon = sorted_latlon[randperm(length(sorted_latlon))]
   shuffled_latlonalt = sorted_latlonalt[randperm(length(sorted_latlonalt))]
   shuffled_geocentriclatlon = sorted_geocentriclatlon[randperm(length(sorted_geocentriclatlon))]
@@ -67,14 +67,13 @@ end
   @test sort(shuffled_geocentriclatlonalt) == sorted_geocentriclatlonalt
 
   @test sort_by_field(shuffled_latlon, :lon) == sorted_lonlat
-  @test sort_by_field(shuffled_latlonalt, [:alt,:lon,:lat]) == sorted_altlonlat
+  @test sort_by_field(shuffled_latlonalt, [:alt, :lon, :lat]) == sorted_altlonlat
   @test sort_by_field(shuffled_latlonalt, :alt) == sorted_altlatlon
 
   @test sort_by_field(shuffled_latlon, "lon") == sorted_lonlat
-  @test sort_by_field(shuffled_latlonalt, ["alt","lon","lat"]) == sorted_altlonlat
+  @test sort_by_field(shuffled_latlonalt, ["alt", "lon", "lat"]) == sorted_altlonlat
   @test sort_by_field(shuffled_latlonalt, "alt") == sorted_altlatlon
 
   @test sort_by_field!(shuffled_latlon, :lon) == sorted_lonlat
-  @test sort_by_field!(shuffled_latlonalt, [:alt,:lon,:lat]) == sorted_altlonlat
-
+  @test sort_by_field!(shuffled_latlonalt, [:alt, :lon, :lat]) == sorted_altlonlat
 end


### PR DESCRIPTION
Since it could be useful to work with ordered geographic types in dataframes or graphics, I added a comparison function (isless) that uses the fields of the geographical type to compare two entries.

- During the sorting the fields are transformed into a tuple and they are compared lexonomically:

```julia
julia> (LatLon(2,1) > LatLon(1,2)) 
true
```
- To compare based on a different order, it is possible to use the function isless
```julia
julia> isless(LatLon(2,1),LatLon(1,2), :lon)
truedata frames
```

- To simplify sorting, I created and exported the function `sort_by_field` and the inplace version `sort_by_field!`. These functions takes 2 arguments, an array of Geographic types and the field order `s`, and return a sorted array.

The functions are alias for the `Base.sort` and `Base.sort!` with the named option `lt=(x,y)->isless(x,y,s)` .

I included the test and documentation for the new functions.