### PR TITLE
Adding EPSG:2180 for usage in vector-benchmark tests

### DIFF
--- a/src/get.jl
+++ b/src/get.jl
@@ -80,6 +80,7 @@ end
 @crscode ESRI{54042} WinkelTripel{WGS84Latest}
 @crscode ESRI{102035} Orthographic{SphericalMode,90°,WGS84Latest}
 @crscode ESRI{102037} Orthographic{SphericalMode,-90°,WGS84Latest}
+@crscode EPSG{2180} shift(TransverseMercator{0.9993,0.0°,NoDatum}, lonₒ=19.0°, xₒ=500000.0m, yₒ=-5300000.0m)
 
 for zone in 1:60
   NorthCode = 32600 + zone

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -25,7 +25,8 @@ const esriid2code = Dict(
   "World_Behrmann" => ESRI{54017},
   "World_Cylindrical_Equal_Area" => ESRI{54034},
   "World_Robinson" => ESRI{54030},
-  "World_Winkel_Tripel_NGS" => ESRI{54042}
+  "World_Winkel_Tripel_NGS" => ESRI{54042},
+  "ETRF2000-PL / CS92" => EPSG{2180}
 )
 
 """

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -7,6 +7,7 @@
 # dictionary in **alphabetical order**
 const esriid2code = Dict(
   "British_National_Grid" => EPSG{27700},
+  "ETRF2000-PL_CS92" => EPSG{2180},
   "GCS_MAGNA" => EPSG{4686},
   "GCS_North_American_1983" => EPSG{4269},
   "GCS_SAD_1969_96" => EPSG{5527},
@@ -25,8 +26,7 @@ const esriid2code = Dict(
   "World_Behrmann" => ESRI{54017},
   "World_Cylindrical_Equal_Area" => ESRI{54034},
   "World_Robinson" => ESRI{54030},
-  "World_Winkel_Tripel_NGS" => ESRI{54042},
-  "ETRF2000-PL / CS92" => EPSG{2180}
+  "World_Winkel_Tripel_NGS" => ESRI{54042}
 )
 
 """

--- a/test/get.jl
+++ b/test/get.jl
@@ -25,6 +25,10 @@
     EPSG{29903},
     CoordRefSystems.shift(TransverseMercator{1.000035,53.5°,Ire65}, lonₒ=-8.0°, xₒ=200000.0m, yₒ=250000.0m)
   )
+  gettest(
+    EPSG{2180},
+    CoordRefSystems.shift(TransverseMercator{0.9993,0.0°,NoDatum}, lonₒ=19.0°, xₒ=500000.0m, yₒ=-5300000.0m)
+  )
   gettest(EPSG{32662}, PlateCarree{WGS84Latest})
   gettest(ESRI{54017}, Behrmann{WGS84Latest})
   gettest(ESRI{54030}, Robinson{WGS84Latest})


### PR DESCRIPTION
I want to add `GeoStats.jl` to [vector-benchmark](https://github.com/kadyb/vector-benchmark/tree/main) (to encourage completeness since they have `GeometryOps.jl`), however, they use [EPSG:2180](https://epsg.org/crs_2180/ETRF2000-PL-CS92.html?sessionkey=ow2y9sx33p). Some functions are spatially related, so preserving CRS is useful.