### PR TITLE
Add 'ETRS89' datum and EPSG:25832

### DIFF
--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -47,6 +47,7 @@ export
   ITRFLatest,
   Aratu,
   Carthage,
+  ETRS89,
   GGRS87,
   GRS80S,
   Hermannskogel,

--- a/src/datums.jl
+++ b/src/datums.jl
@@ -132,6 +132,17 @@ abstract type Carthage <: Datum end
 ellipsoid(::Type{Carthage}) = Clrk80IGN🌎
 
 """
+    ETRS89
+
+European Terrestrial Reference System 1989.
+
+See <https://epsg.org/datum_6258/European-Terrestrial-Reference-System-1989-ensemble.html>
+"""
+abstract type ETRS89 <: Datum end
+
+ellipsoid(::Type{ETRS89}) = GRS80🌎
+
+"""
     GGRS87
 
 Greek Geodetic Reference System 1987 datum.

--- a/src/get.jl
+++ b/src/get.jl
@@ -71,6 +71,7 @@ end
 @crscode EPSG{5527} LatLon{SAD96}
 @crscode EPSG{9988} Cartesian3D{ITRF{2020}}
 @crscode EPSG{10176} Cartesian3D{IGS20}
+@crscode EPSG{25832} shift(TransverseMercator{0.9996,0.0°,ETRS89}, lonₒ=9.0°, xₒ=500000.0m, yₒ=0.0m)
 @crscode EPSG{27700} shift(TransverseMercator{0.9996012717,49.0°,OSGB36}, lonₒ=-2.0°, xₒ=400000.0m, yₒ=-100000.0m)
 @crscode EPSG{29903} shift(TransverseMercator{1.000035,53.5°,Ire65}, lonₒ=-8.0°, xₒ=200000.0m, yₒ=250000.0m)
 @crscode EPSG{32662} PlateCarree{WGS84Latest}

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -19,6 +19,7 @@ const esriid2code = Dict(
   "North_Pole_Orthographic" => ESRI{102035},
   "South_Pole_Orthographic" => ESRI{102037},
   "TM75_Irish_Grid" => EPSG{29903},
+  "ETRS_1989_UTM_Zone_32N" => EPSG{25832},
   "WGS_1984_Plate_Carree" => EPSG{32662},
   "WGS_1984_UTM_Zone_33N" => EPSG{32633},
   "WGS_1984_Web_Mercator_Auxiliary_Sphere" => EPSG{3857},

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -8,6 +8,7 @@
 const esriid2code = Dict(
   "British_National_Grid" => EPSG{27700},
   "ETRF2000-PL_CS92" => EPSG{2180},
+  "ETRS_1989_UTM_Zone_32N" => EPSG{25832},
   "GCS_MAGNA" => EPSG{4686},
   "GCS_North_American_1983" => EPSG{4269},
   "GCS_SAD_1969_96" => EPSG{5527},
@@ -19,7 +20,6 @@ const esriid2code = Dict(
   "North_Pole_Orthographic" => ESRI{102035},
   "South_Pole_Orthographic" => ESRI{102037},
   "TM75_Irish_Grid" => EPSG{29903},
-  "ETRS_1989_UTM_Zone_32N" => EPSG{25832},
   "WGS_1984_Plate_Carree" => EPSG{32662},
   "WGS_1984_UTM_Zone_33N" => EPSG{32633},
   "WGS_1984_Web_Mercator_Auxiliary_Sphere" => EPSG{3857},

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -263,3 +263,17 @@ include("transforms/sequential.jl")
 @reversible WGS84{1674} WGS84{2296} @sequential(WGS84{1674}, WGS84{1762}, WGS84{2139}, WGS84{2296})
 
 @reversible WGS84{1762} WGS84{2296} @sequential(WGS84{1762}, WGS84{2139}, WGS84{2296})
+
+# https://epsg.org/transformation_9225/WGS-84-to-ETRS89-2.html
+@reversible WGS84{2296} ETRS89 timedephelmert(
+  WGS84{2296},
+  ETRS89,
+  δx=54.0e-3,
+  δy=51.0e-3,
+  δz=-85.0e-3,
+  θx=2.1e-3,
+  θy=12.6e-3,
+  θz=-20.4e-3,
+  s=2.5e-3,
+  tᵣ=2014.81
+)

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -263,17 +263,3 @@ include("transforms/sequential.jl")
 @reversible WGS84{1674} WGS84{2296} @sequential(WGS84{1674}, WGS84{1762}, WGS84{2139}, WGS84{2296})
 
 @reversible WGS84{1762} WGS84{2296} @sequential(WGS84{1762}, WGS84{2139}, WGS84{2296})
-
-# https://epsg.org/transformation_9225/WGS-84-to-ETRS89-2.html
-@reversible WGS84{2296} ETRS89 timedephelmert(
-  WGS84{2296},
-  ETRS89,
-  δx=54.0e-3,
-  δy=51.0e-3,
-  δz=-85.0e-3,
-  θx=2.1e-3,
-  θy=12.6e-3,
-  θz=-20.4e-3,
-  s=2.5e-3,
-  tᵣ=2014.81
-)

--- a/test/datums.jl
+++ b/test/datums.jl
@@ -26,6 +26,8 @@
 
   @test ellipsoid(Carthage) === CoordRefSystems.Clrk80IGN🌎
 
+  @test ellipsoid(ETRS89) === CoordRefSystems.GRS80🌎
+
   @test ellipsoid(GGRS87) === CoordRefSystems.GRS80🌎
 
   @test ellipsoid(GRS80S) === CoordRefSystems.GRS80S🌎

--- a/test/get.jl
+++ b/test/get.jl
@@ -18,6 +18,10 @@
   gettest(EPSG{9988}, Cartesian{ITRF{2020},3})
   gettest(EPSG{10176}, Cartesian{IGS20,3})
   gettest(
+    EPSG{25832},
+    CoordRefSystems.shift(TransverseMercator{0.9996,0.0°,ETRS89}, lonₒ=9.0°, xₒ=500000.0m, yₒ=0.0m)
+  )
+  gettest(
     EPSG{27700},
     CoordRefSystems.shift(TransverseMercator{0.9996012717,49.0°,OSGB36}, lonₒ=-2.0°, xₒ=400000.0m, yₒ=-100000.0m)
   )

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -10,6 +10,7 @@
   crsstringtest(EPSG{5527})
   crsstringtest(EPSG{32662})
   crsstringtest(EPSG{32633})
+  crsstringtest(EPSG{25832})
   crsstringtest(EPSG{27700})
   crsstringtest(EPSG{29903})
   crsstringtest(ESRI{54017})


### PR DESCRIPTION
Adds the European Terrestrial Reference System 1989 (`ETRS89`) datum and ETRS_1989_UTM_Zone_32N (`EPSG{25832}`). Please check if the transformation from `WGS84{2296}` to `ETRS89` is correctly implemented. Thanks!