### PR TITLE
Replace Zygote by ForwardDiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,16 +4,16 @@ authors = ["Elias Carvalho <eliascarvdev@gmail.com>", "Júlio Hoffimann <julio.h
 version = "0.15.5"
 
 [deps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
+ForwardDiff = "0.10.37"
 Random = "1.9"
 Rotations = "1.7"
 StaticArrays = "1.9"
 Unitful = "1.19"
-Zygote = "0.6"
 julia = "1.9"

--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -7,7 +7,7 @@ module CoordRefSystems
 using Unitful
 using Unitful: numtype
 using Unitful: m, rad, °
-using Zygote: gradient
+using ForwardDiff: gradient
 using Rotations: RotXYZ
 using StaticArrays: SVector
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -136,16 +136,19 @@ initial guess `λₒ` and `ϕₒ`, `maxiter` iterations, and tolerance `tol`.
   MATRICES](https://www.researchgate.net/publication/241170163_A_GENERAL_ALGORITHM_FOR_THE_INVERSE_TRANSFORMATION_OF_MAP_PROJECTIONS_USING_JACOBIAN_MATRICES)
 """
 function projinv(fx, fy, x, y, λₒ, ϕₒ; maxiter=10, tol=atol(x))
-  f₁(λ, ϕ) = fx(λ, ϕ) - x
-  f₂(λ, ϕ) = fy(λ, ϕ) - y
+  f₁(λϕ) = fx(λϕ...) - x
+  f₂(λϕ) = fy(λϕ...) - y
+
   λᵢ₊₁ = λᵢ = λₒ
   ϕᵢ₊₁ = ϕᵢ = ϕₒ
-
   for _ in 1:maxiter
-    v₁ = f₁(λᵢ, ϕᵢ)
-    v₂ = f₂(λᵢ, ϕᵢ)
-    df₁dλ, df₁dϕ = gradient(f₁, λᵢ, ϕᵢ)
-    df₂dλ, df₂dϕ = gradient(f₂, λᵢ, ϕᵢ)
+    λϕᵢ = SVector(λᵢ, ϕᵢ)
+
+    v₁ = f₁(λϕᵢ)
+    v₂ = f₂(λϕᵢ)
+
+    df₁dλ, df₁dϕ = gradient(f₁, λϕᵢ)
+    df₂dλ, df₂dϕ = gradient(f₂, λϕᵢ)
 
     den = (df₁dϕ * df₂dλ - df₂dϕ * df₁dλ)
     λᵢ₊₁ = λᵢ - (v₂ * df₁dϕ - v₁ * df₂dϕ) / den


### PR DESCRIPTION
As discussed on Zulip, ForwardDiff.jl is more adequate than Zygote.jl in this case. It is also a lighter dependency.