### PR TITLE
Fix `isapprox` of `Projected`

### DIFF
--- a/src/crs.jl
+++ b/src/crs.jl
@@ -120,11 +120,9 @@ mactype(C::Type{<:CRS}) = numtype(lentype(C))
 """
     isapprox(coords₁, coords₂; kwargs...)
 
-Checks whether the cartesian coordinates of `coords₁` and `coords₂`
-are approximated using the `isapprox` function and taking into account the Datum.
-The type of `Cartesian` used in the comparison depends on the type of CRS, 
-`Geographic` and `Projected` use `Cartesian3D`, while `Basic` use the type
-with the same number of dimensions.
+Converts `coords₁` and `coords₂` to `Cartesian` coordinates and compare the coordinate
+values with the `isapprox` method of vectors. The conversion to `Cartesian` coordinates
+takes care of possibly different `Datum`.
 """
 Base.isapprox(coords₁::CRS, coords₂::CRS; kwargs...) =
   isapprox(convert(Cartesian, coords₁), convert(Cartesian, coords₂); kwargs...)

--- a/src/crs.jl
+++ b/src/crs.jl
@@ -120,8 +120,11 @@ mactype(C::Type{<:CRS}) = numtype(lentype(C))
 """
     isapprox(coords₁, coords₂; kwargs...)
 
-Checks whether the coordinates `coords₁` and `coords₂`
-are approximate using the `isapprox` function.
+Checks whether the cartesian coordinates of `coords₁` and `coords₂`
+are approximated using the `isapprox` function and taking into account the Datum.
+The type of `Cartesian` used in the comparison depends on the type of CRS, 
+`Geographic` and `Projected` use `Cartesian3D`, while `Basic` use the type
+with the same number of dimensions.
 """
 Base.isapprox(coords₁::CRS, coords₂::CRS; kwargs...) =
   isapprox(convert(Cartesian, coords₁), convert(Cartesian, coords₂); kwargs...)

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -81,6 +81,7 @@ function indomain(C::Type{<:Projected}, (; lat, lon)::LatLon)
   inbounds(C, ustrip(deg2rad(lon - lonₒ)), ustrip(deg2rad(lat)))
 end
 
+# convert to Cartesian3D through a common LatLon
 Base.isapprox(coords₁::Projected{Datum}, coords₂::Projected{Datum}; kwargs...) where {Datum} =
   isapprox(convert(Cartesian3D, coords₁), convert(Cartesian3D, coords₂); kwargs...)
 

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -82,7 +82,7 @@ function indomain(C::Type{<:Projected}, (; lat, lon)::LatLon)
 end
 
 Base.isapprox(coords₁::Projected{Datum}, coords₂::Projected{Datum}; kwargs...) where {Datum} =
-  isapprox(convert(Cartesian, coords₁), convert(Cartesian, coords₂); kwargs...)
+  isapprox(convert(Cartesian3D, coords₁), convert(Cartesian3D, coords₂); kwargs...)
 
 Base.isapprox(coords₁::Projected{Datum₁}, coords₂::Projected{Datum₂}; kwargs...) where {Datum₁,Datum₂} =
   isapprox(convert(Cartesian{Datum₁,3}, coords₁), convert(Cartesian{Datum₂,3}, coords₂); kwargs...)

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -85,6 +85,12 @@ end
 Base.isapprox(coords₁::Projected, coords₂::Projected; kwargs...) =
   isapprox(convert(Cartesian3D, coords₁), convert(Cartesian3D, coords₂); kwargs...)
 
+Base.isapprox(coords₁::Projected, coords₂::CRS; kwargs...) =
+  isapprox(convert(Cartesian3D, coords₁), convert(Cartesian, coords₂); kwargs...)
+
+Base.isapprox(coords₁::CRS, coords₂::Projected; kwargs...) =
+  isapprox(convert(Cartesian, coords₁), convert(Cartesian3D, coords₂); kwargs...)
+
 function Random.rand(rng::Random.AbstractRNG, ::Type{C}) where {C<:Projected}
   try
     convert(C, rand(rng, LatLon))

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -82,11 +82,8 @@ function indomain(C::Type{<:Projected}, (; lat, lon)::LatLon)
 end
 
 # convert to Cartesian3D through a common LatLon
-Base.isapprox(coords₁::Projected{Datum}, coords₂::Projected{Datum}; kwargs...) where {Datum} =
+Base.isapprox(coords₁::Projected, coords₂::Projected; kwargs...) =
   isapprox(convert(Cartesian3D, coords₁), convert(Cartesian3D, coords₂); kwargs...)
-
-Base.isapprox(coords₁::Projected{Datum₁}, coords₂::Projected{Datum₂}; kwargs...) where {Datum₁,Datum₂} =
-  isapprox(convert(Cartesian{Datum₁,3}, coords₁), convert(Cartesian{Datum₂,3}, coords₂); kwargs...)
 
 function Random.rand(rng::Random.AbstractRNG, ::Type{C}) where {C<:Projected}
   try

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -40,6 +40,11 @@ function isapproxtest3D(CRS; datum1=WGS84{1762}, datum2=ITRF{2008})
   cart = CRS <: CoordRefSystems.Projected ? convert(Cartesian3D, c) : convert(Cartesian, c)
   u = CoordRefSystems.lentype(cart) |> unit
 
+  # basic tests
+  @test c ≈ cart
+  @test cart ≈ c
+
+  # translated coordinates
   c1 = convert(CRS, Cartesian{datum1}(cart.x, cart.y, cart.z))
 
   τ = CoordRefSystems.atol(Float64) * u
@@ -64,6 +69,7 @@ function isapproxtest3D(CRS; datum1=WGS84{1762}, datum2=ITRF{2008})
   @test c1 ≈ c3
   @test c1 ≈ c4
 
+  # different datums
   c2 = convert(CRS, Cartesian{datum2}(cart.x, cart.y, cart.z))
   @test c1 ≈ c2
 end


### PR DESCRIPTION
Now, `isapprox` of `Projected` is using `Cartesian3D` coordinates in the comparison.

master:
```julia
julia> c1 = Mercator(1000, 1000)
Mercator{WGS84Latest} coordinates
├─ x: 1000.0 m
└─ y: 1000.0 m

julia> c2 = GallPeters(1000, 1000)
GallPeters{WGS84Latest} coordinates
├─ x: 1000.0 m
└─ y: 1000.0 m

julia> c1 ≈ c2
true
```

PR:
```julia
julia> c1 = Mercator(1000, 1000)
Mercator{WGS84Latest} coordinates
├─ x: 1000.0 m
└─ y: 1000.0 m

julia> c2 = GallPeters(1000, 1000)
GallPeters{WGS84Latest} coordinates
├─ x: 1000.0 m
└─ y: 1000.0 m

julia> c1 ≈ c2
false
```