### PR TITLE
Fix `inbounds` implementations

### DIFF
--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -69,7 +69,10 @@ end
 
 Checks whether `λ` and `ϕ` in radians are within the `CRS` domain.
 """
-inbounds(::Type{<:Projected}, λ, ϕ) = -π ≤ λ ≤ π && -π / 2 ≤ ϕ ≤ π / 2
+function inbounds(::Type{<:Projected}, λ, ϕ)
+  T = typeof(λ)
+  -T(π) ≤ λ ≤ T(π) && -T(π) / 2 ≤ ϕ ≤ T(π) / 2
+end
 
 """
     indomain(CRS::Type{<:Projected}, latlon::LatLon)

--- a/src/crs/projected/mercator.jl
+++ b/src/crs/projected/mercator.jl
@@ -51,7 +51,10 @@ isconformal(::Type{<:Mercator}) = true
 # CONVERSIONS
 # ------------
 
-inbounds(::Type{<:Mercator}, λ, ϕ) = -π ≤ λ ≤ π && -deg2rad(80) ≤ ϕ ≤ deg2rad(84)
+function inbounds(::Type{<:Mercator}, λ, ϕ)
+  T = typeof(λ)
+  -T(π) ≤ λ ≤ T(π) && deg2rad(-T(80)) ≤ ϕ ≤ deg2rad(T(84))
+end
 
 function formulas(::Type{<:Mercator{Datum}}, ::Type{T}) where {Datum,T}
   e = T(eccentricity(ellipsoid(Datum)))

--- a/src/crs/projected/orthographic.jl
+++ b/src/crs/projected/orthographic.jl
@@ -92,14 +92,21 @@ const OrthoSouth{Datum,Shift} = Orthographic{EllipticalMode,-90°,Datum,Shift}
 #                     https://epsg.org/guidance-notes.html
 
 function inbounds(::Type{<:Orthographic{Mode,latₒ}}, λ, ϕ) where {Mode,latₒ}
+  T = typeof(λ)
   ϕₒ = ustrip(deg2rad(latₒ))
   c = acos(sin(ϕₒ) * sin(ϕ) + cos(ϕₒ) * cos(ϕ) * cos(λ))
-  -π / 2 < c < π / 2
+  -T(π) / 2 < c < T(π) / 2
 end
 
-inbounds(::Type{<:OrthoNorth}, λ, ϕ) = -π ≤ λ ≤ π && 0 ≤ ϕ ≤ π / 2
+function inbounds(::Type{<:OrthoNorth}, λ, ϕ)
+  T = typeof(λ)  
+  -T(π) ≤ λ ≤ T(π) && T(0) ≤ ϕ ≤ T(π) / 2
+end
 
-inbounds(::Type{<:OrthoSouth}, λ, ϕ) = -π ≤ λ ≤ π && -π / 2 ≤ ϕ ≤ 0
+function inbounds(::Type{<:OrthoSouth}, λ, ϕ)
+  T = typeof(λ)  
+  -T(π) ≤ λ ≤ T(π) && -T(π) / 2 ≤ ϕ ≤ T(0)
+end
 
 function formulas(::Type{<:Orthographic{EllipticalMode,latₒ,Datum}}, ::Type{T}) where {latₒ,Datum,T}
   ϕₒ = T(ustrip(deg2rad(latₒ)))

--- a/src/crs/projected/webmercator.jl
+++ b/src/crs/projected/webmercator.jl
@@ -53,8 +53,9 @@ iscompromise(::Type{<:WebMercator}) = true
 # ------------
 
 function inbounds(::Type{<:WebMercator}, λ, ϕ)
-  θ = deg2rad(85.06)
-  -π ≤ λ ≤ π && -θ ≤ ϕ ≤ θ
+  T = typeof(λ)
+  θ = deg2rad(T(85.06))
+  -T(π) ≤ λ ≤ T(π) && -θ ≤ ϕ ≤ θ
 end
 
 function formulas(::Type{<:WebMercator}, ::Type{T}) where {T}

--- a/test/crs/domains.jl
+++ b/test/crs/domains.jl
@@ -26,7 +26,7 @@
     elseif C <: Behrmann
       T === Float32 ? 1.0f-2° : 1e-4°
     elseif C <: GallPeters
-      T === Float32 ? 1.0f-2° : 1e-4°
+      T === Float32 ? 1.0f-1° : 1e-4°
     elseif C <: Robinson
       T(1e-3) * °
     elseif C <: Albers


### PR DESCRIPTION
The master version is generating false negatives.
main:
```julia
julia> c = LatLon(0, -180)
GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 0.0°
└─ lon: -180.0°

julia> indomain(Mercator, c)
true

julia> c = LatLon(0f0, -180f0)
GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 0.0f0°
└─ lon: -180.0f0°

julia> indomain(Mercator, c)
false
```
PR:
```julia
julia> c = LatLon(0, -180)
GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 0.0°
└─ lon: -180.0°

julia> indomain(Mercator, c)
true

julia> c = LatLon(0f0, -180f0)
GeodeticLatLon{WGS84Latest} coordinates
├─ lat: 0.0f0°
└─ lon: -180.0f0°

julia> indomain(Mercator, c)
true
```