### PR TITLE
Add fallback to `inbounds` of `TransverseMercator` and `Albers`

### DIFF
--- a/src/crs/projected/albers.jl
+++ b/src/crs/projected/albers.jl
@@ -160,5 +160,8 @@ _albersα(ϕ, e, e²) =
 # FALLBACKS
 # ----------
 
+inbounds(::Type{Albers{latₒ,lat₁,lat₂}}, λ, ϕ) where {latₒ,lat₁,lat₂} =
+  inbounds(Albers{latₒ,lat₁,lat₂,WGS84Latest}, λ, ϕ)
+
 Base.convert(::Type{Albers{latₒ,lat₁,lat₂}}, coords::CRS{Datum}) where {latₒ,lat₁,lat₂,Datum} =
   convert(Albers{latₒ,lat₁,lat₂,Datum}, coords)

--- a/src/crs/projected/transversemercator.jl
+++ b/src/crs/projected/transversemercator.jl
@@ -149,6 +149,9 @@ end
 # FALLBACKS
 # ----------
 
+inbounds(::Type{TransverseMercator{k₀,latₒ}}, λ, ϕ) where {k₀,latₒ} =
+  inbounds(TransverseMercator{k₀,latₒ,WGS84Latest}, λ, ϕ)
+
 Base.convert(::Type{TransverseMercator{k₀,latₒ}}, coords::CRS{Datum}) where {k₀,latₒ,Datum} =
   convert(TransverseMercator{k₀,latₒ,Datum}, coords)
 

--- a/test/crs/domains.jl
+++ b/test/crs/domains.jl
@@ -1,13 +1,5 @@
 @testset "Projection domain" begin
-  for P in projected
-    C = if P <: TransverseMercator
-      P{WGS84Latest}
-    elseif P <: Albers
-      P{WGS84Latest}
-    else
-      P
-    end
-
+  for C in projected
     # forward
     for lat in T.(-90:90), lon in T.(-180:180)
       c1 = LatLon(lat, lon)


### PR DESCRIPTION
This PR adds fallbacks for `TransverseMercator` and `Albers` types that don't have the Datum.