### PR TITLE
Reduce atol on LambertAzimuthalEqualArea tests

### DIFF
--- a/test/crs/domains.jl
+++ b/test/crs/domains.jl
@@ -130,7 +130,7 @@
           end
         end
       else
-        atol = 1e10°
+        atol = 1e-6°
         for lat in T.(-89:89), lon in T.(-180:180)
           c1 = LatLon(lat, lon)
           if indomain(C, c1)


### PR DESCRIPTION
This PR reduces the `atol` in the `LambertAzimuthalEqualArea` test from 1e10 degrees (way too big!) to 1e-6 deg. I found this while working on the EPSG:3031 project and it seemed like an easy fix. All tests are passing locally!