### PR TITLE
Add GDA94 datum for Australia

### DIFF
--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -56,6 +56,7 @@ export
   ED50,
   ED79,
   ED87,
+  GDA94,
   GGRS87,
   GRS80S,
   Hermannskogel,

--- a/src/datums.jl
+++ b/src/datums.jl
@@ -23,6 +23,24 @@ Returns the reference epoch of the datum type `D`.
 """
 function epoch end
 
+"""
+    ShiftedDatum{Datum,Epoch}
+
+Shifted `Datum` with a given `Epoch` in decimalyear.
+"""
+abstract type ShiftedDatum{D,Epoch} <: Datum end
+
+ellipsoid(::Type{ShiftedDatum{D,Epoch}}) where {D,Epoch} = ellipsoid(D)
+
+epoch(::Type{ShiftedDatum{D,Epoch}}) where {D,Epoch} = Epoch
+
+"""
+    CoordRefSystems.shift(Datum, epoch)
+
+Shifts the `Datum` with a given `epoch` in decimalyear.
+"""
+shift(D::Type{<:Datum}, epoch) = ShiftedDatum{D,epoch}
+
 # ----------------
 # IMPLEMENTATIONS
 # ----------------
@@ -40,17 +58,6 @@ function epoch end
 Represents the absence of datum in a CRS.
 """
 abstract type NoDatum <: Datum end
-
-"""
-    ShiftedDatum{Datum,Epoch}
-
-Shifted `Datum` with a given `Epoch` in decimalyear.
-"""
-abstract type ShiftedDatum{D,Epoch} <: Datum end
-
-ellipsoid(::Type{ShiftedDatum{D,Epoch}}) where {D,Epoch} = ellipsoid(D)
-
-epoch(::Type{ShiftedDatum{D,Epoch}}) where {D,Epoch} = Epoch
 
 """
     WGS84{GPSWeek}
@@ -245,6 +252,15 @@ See <https://epsg.org/datum_6231/European-Datum-1987.html>
 abstract type ED87 <: Datum end
 
 ellipsoid(::Type{ED87}) = Intl🌎
+
+"""
+    GDA94
+
+Geocentric datum of Australia 1994.
+
+See <https://epsg.org/datum_6283/Geocentric-Datum-of-Australia-1994.html>
+"""
+const GDA94 = shift(ITRF{1992}, 1994.0)
 
 """
     GGRS87

--- a/src/shift.jl
+++ b/src/shift.jl
@@ -23,10 +23,3 @@ Shifts the `CRS` with given longitude origin `lonₒ` in degrees, false easting 
 and false northing `yₒ` in meters.
 """
 shift(CRS::Type{<:Projected}; lonₒ=0.0°, xₒ=0.0m, yₒ=0.0m) = CRS{Shift(; lonₒ, xₒ, yₒ)}
-
-"""
-    CoordRefSystems.shift(Datum, epoch)
-
-Shifts the `Datum` with a given `epoch` in decimalyear.
-"""
-shift(D::Type{<:Datum}, epoch) = ShiftedDatum{D,epoch}

--- a/test/datums.jl
+++ b/test/datums.jl
@@ -45,6 +45,10 @@
   @test epoch(NAD83CSRS{7}) == 2010.0
   @test epoch(NAD83CSRS{8}) == 2010.0
 
+  ShiftedWGS84 = CoordRefSystems.shift(WGS84Latest, 2024.0)
+  @test ellipsoid(ShiftedWGS84) === CoordRefSystems.WGS84🌎
+  @test epoch(ShiftedWGS84) == 2024.0
+
   @test ellipsoid(Aratu) === CoordRefSystems.Intl🌎
 
   @test ellipsoid(Carthage) === CoordRefSystems.Clrk80IGN🌎
@@ -58,6 +62,9 @@
   @test ellipsoid(ED79) === CoordRefSystems.Intl🌎
 
   @test ellipsoid(ED87) === CoordRefSystems.Intl🌎
+
+  @test ellipsoid(GDA94) === CoordRefSystems.GRS80🌎
+  @test epoch(GDA94) == 1994.0
 
   @test ellipsoid(GGRS87) === CoordRefSystems.GRS80🌎
 
@@ -108,8 +115,4 @@
   @test ellipsoid(SAD96) === CoordRefSystems.GRS67Modified🌎
 
   @test ellipsoid(SIRGAS2000) === CoordRefSystems.GRS80🌎
-
-  ShiftedWGS84 = CoordRefSystems.shift(WGS84Latest, 2024.0)
-  @test ellipsoid(ShiftedWGS84) === CoordRefSystems.WGS84🌎
-  @test epoch(ShiftedWGS84) == 2024.0
 end


### PR DESCRIPTION
Reference: https://epsg.org/datum_6283/Geocentric-Datum-of-Australia-1994.html

I also refactored the code to move the `shift` functionality near the datum types.