### PR TITLE
add EPSG 2193

### DIFF
--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -72,6 +72,7 @@ export
   NAD83,
   NTF,
   NZGD1949,
+  NZGD2000,
   OSGB36,
   PD83,
   Potsdam,

--- a/src/datums.jl
+++ b/src/datums.jl
@@ -414,7 +414,7 @@ abstract type NZGD1949 <: Datum end
 ellipsoid(::Type{NZGD1949}) = Intl🌎
 
 """
-    Nzgd2000
+    NZGD2000
 
 New Zealand Geodetic Datum 2000.
 """

--- a/src/datums.jl
+++ b/src/datums.jl
@@ -414,6 +414,15 @@ abstract type NZGD1949 <: Datum end
 ellipsoid(::Type{NZGD1949}) = Intl🌎
 
 """
+    Nzgd2000
+
+New Zealand Geodetic Datum 2000.
+"""
+abstract type NZGD2000 <: Datum end
+
+ellipsoid(::Type{NZGD2000}) = GRS80🌎
+
+"""
     OSGB36
 
 Ordnance Survey of Great Britain 1936 datum.

--- a/src/get.jl
+++ b/src/get.jl
@@ -44,6 +44,7 @@ end
 # ----------------
 
 @crscode EPSG{2157} shift(TransverseMercator{0.99982,53.5°,IRENET95}, lonₒ=-8.0°, xₒ=600000.0m, yₒ=750000.0m)
+@crscode EPSG{2193} shift(TransverseMercator{0.9996,0.0°,NZGD2000}, lonₒ=173.0°, xₒ=1600000.0m, yₒ=10000000.0m)
 @crscode EPSG{3035} shift(LambertAzimuthalEqualArea{52.0°,ETRFLatest}, lonₒ=-10.0°, xₒ=4321000.0m, yₒ=-3210000.0m)
 @crscode EPSG{3310} shift(Albers{0.0°,34.0°,40.5°,NAD83}, lonₒ=-120.0°, yₒ=-4000000.0m)
 @crscode EPSG{3395} Mercator{WGS84Latest}

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -44,6 +44,7 @@ const esriid2code = Dict(
   "NAD_1983_California_Teale_Albers" => EPSG{3310},
   "NAD_1983_Contiguous_USA_Albers" => EPSG{5070},
   "North_Pole_Orthographic" => ESRI{102035},
+  "NZGD_2000_New_Zealand_Transverse_Mercator" => EPSG{2193},
   "RGF93_v2" => EPSG{9777},
   "RGF93_v2b" => EPSG{9782},
   "South_Pole_Orthographic" => ESRI{102037},

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -36,6 +36,9 @@ include("transforms/sequential.jl")
 # https://epsg.org/transformation_1149/ETRS89-to-WGS-84-1.html
 @identity ETRF{2020} WGS84{2296}
 
+# https://epsg.org/transformation_1565/NZGD2000-to-WGS-84-1.html
+@identity NZGD2000 WGS84
+
 # https://epsg.org/transformation_1130/Carthage-to-WGS-84-1.html
 @geoctranslation Carthage WGS84 (δx=-263.0, δy=6.0, δz=431.0)
 

--- a/test/datums.jl
+++ b/test/datums.jl
@@ -96,6 +96,8 @@
 
   @test ellipsoid(NZGD1949) === CoordRefSystems.Intl🌎
 
+  @test ellipsoid(NZGD2000) === CoordRefSystems.GRS80🌎
+
   @test ellipsoid(OSGB36) === CoordRefSystems.Airy🌎
 
   @test ellipsoid(PD83) === CoordRefSystems.Bessel🌎

--- a/test/get.jl
+++ b/test/get.jl
@@ -5,6 +5,10 @@
     CoordRefSystems.shift(TransverseMercator{0.99982,53.5°,IRENET95}, lonₒ=-8.0°, xₒ=600000.0m, yₒ=750000.0m)
   )
   gettest(
+    EPSG{2193},
+    CoordRefSystems.shift(TransverseMercator{0.9996,0.0°,NZGD2000}, lonₒ=173.0°, xₒ=1600000.0m, yₒ=10000000.0m)
+  )
+  gettest(
     EPSG{3035},
     CoordRefSystems.shift(LambertAzimuthalEqualArea{52.0°,ETRFLatest}, lonₒ=-10.0°, xₒ=4321000.0m, yₒ=-3210000.0m)
   )

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1,6 +1,7 @@
 @testset "strings" begin
   # EPSG codes
   crsstringtest(EPSG{2157})
+  crsstringtest(EPSG{2193})
   crsstringtest(EPSG{3035})
   crsstringtest(EPSG{3310})
   crsstringtest(EPSG{3395})


### PR DESCRIPTION
Add EPSG 2193 (NZ Transverse Mercator 2000) as specified in [epsg.io/2193](https://epsg.io/2193). This allows reading files downloaded in the default format from Stats New Zealand [datafinder.stats.govt.nz](https://datafinder.stats.govt.nz/) .

It also required adding the datum NZGD2000, and a transform was added from NZGD2000 to WGS84 (identity, as specified [here](https://epsg.org/transformation_1565/NZGD2000-to-WGS-84-1.html).

This is my first time contributing to an open source software project (!), so a review would be much appreciated, as well as any pointers on good practice.