### PR TITLE
Fix EPSG{3035}

### DIFF
--- a/src/get.jl
+++ b/src/get.jl
@@ -45,7 +45,7 @@ end
 
 @crscode EPSG{2157} shift(TransverseMercator{0.99982,53.5°,IRENET95}, lonₒ=-8.0°, xₒ=600000.0m, yₒ=750000.0m)
 @crscode EPSG{2193} shift(TransverseMercator{0.9996,0.0°,NZGD2000}, lonₒ=173.0°, xₒ=1600000.0m, yₒ=10000000.0m)
-@crscode EPSG{3035} shift(LambertAzimuthalEqualArea{52.0°,ETRFLatest}, lonₒ=-10.0°, xₒ=4321000.0m, yₒ=-3210000.0m)
+@crscode EPSG{3035} shift(LambertAzimuthalEqualArea{52.0°,ETRFLatest}, lonₒ=10.0°, xₒ=4321000.0m, yₒ=3210000.0m)
 @crscode EPSG{3310} shift(Albers{0.0°,34.0°,40.5°,NAD83}, lonₒ=-120.0°, yₒ=-4000000.0m)
 @crscode EPSG{3395} Mercator{WGS84Latest}
 @crscode EPSG{3857} WebMercator{WGS84Latest}

--- a/test/get.jl
+++ b/test/get.jl
@@ -10,7 +10,7 @@
   )
   gettest(
     EPSG{3035},
-    CoordRefSystems.shift(LambertAzimuthalEqualArea{52.0°,ETRFLatest}, lonₒ=-10.0°, xₒ=4321000.0m, yₒ=-3210000.0m)
+    CoordRefSystems.shift(LambertAzimuthalEqualArea{52.0°,ETRFLatest}, lonₒ=10.0°, xₒ=4321000.0m, yₒ=3210000.0m)
   )
   gettest(EPSG{3310}, CoordRefSystems.shift(Albers{0.0°,34.0°,40.5°,NAD83}, lonₒ=-120.0°, yₒ=-4000000.0m))
   gettest(EPSG{3395}, Mercator{WGS84Latest})


### PR DESCRIPTION
The "longitude of center" and "false northing" parameters of the EPSG{3035} transformation were corrected according to https://epsg.io/3035 and validated with https://epsg.io/transform#s_srs=4326&t_srs=3035&x=8.4000000&y=49.0000000.