### PR TITLE
Avoid converting to same type at compile time

### DIFF
--- a/src/crs.jl
+++ b/src/crs.jl
@@ -190,6 +190,9 @@ function Base.convert(::Type{C}, coords::CRS) where {C<:CRS}
   convert(C, coords′)
 end
 
+# avoid converting coordinates to the same type at compile time
+Base.convert(::Type{C}, coords::C) where {C<:CRS} = coords
+
 # -----------
 # IO METHODS
 # -----------

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -253,6 +253,3 @@ function Base.convert(::Type{Cₜ}, coords::Cₛ) where {Datumₜ,Datumₛ,Cₜ<
   latlonₜ = convert(LatLon{Datumₜ}, latlonₛ)
   convert(Cₜ, latlonₜ)
 end
-
-# avoid converting coordinates with the same type as the first argument
-Base.convert(::Type{C}, coords::C) where {Datum,C<:Projected{Datum}} = coords


### PR DESCRIPTION
One test is failing due to some unexpected dispatch priority with `OrthoNorth`.

@eliascarv could you please take a look when you find some time? Why do we need the method for `Projected` subtypes to avoid the computation?