### PR TITLE
Rename LambertAzimuthalEqualArea to LambertAzimuthal

### DIFF
--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -120,7 +120,7 @@ export
   TransverseMercator,
   Albers,
   Sinusoidal,
-  LambertAzimuthalEqualArea,
+  LambertAzimuthal,
   EqualEarth,
   datum,
   indomain,

--- a/src/crs/projected.jl
+++ b/src/crs/projected.jl
@@ -158,7 +158,7 @@ include("projected/orthographic.jl")
 include("projected/transversemercator.jl")
 include("projected/albers.jl")
 include("projected/sinusoidal.jl")
-include("projected/lambertazmeqarea.jl")
+include("projected/lambertazm.jl")
 include("projected/equalearth.jl")
 
 # ----------

--- a/src/crs/projected/lambertazm.jl
+++ b/src/crs/projected/lambertazm.jl
@@ -3,45 +3,41 @@
 # ------------------------------------------------------------------
 
 """
-    LambertAzimuthalEqualArea{latₒ,Datum,Shift}
+    LambertAzimuthal{latₒ,Datum,Shift}
 
-Lambert Azimuthal Equal Area CRS with latitude origin `latₒ` in degrees, `Datum` and `Shift`.
+Lambert Azimuthal CRS with latitude origin `latₒ` in degrees, `Datum` and `Shift`.
 """
-struct LambertAzimuthalEqualArea{latₒ,Datum,Shift,M<:Met} <: Projected{Datum,Shift}
+struct LambertAzimuthal{latₒ,Datum,Shift,M<:Met} <: Projected{Datum,Shift}
   x::M
   y::M
 end
 
-LambertAzimuthalEqualArea{latₒ,Datum,Shift}(x::M, y::M) where {latₒ,Datum,Shift,M<:Met} =
-  LambertAzimuthalEqualArea{latₒ,Datum,Shift,float(M)}(x, y)
-LambertAzimuthalEqualArea{latₒ,Datum,Shift}(x::Met, y::Met) where {latₒ,Datum,Shift} =
-  LambertAzimuthalEqualArea{latₒ,Datum,Shift}(promote(x, y)...)
-LambertAzimuthalEqualArea{latₒ,Datum,Shift}(x::Len, y::Len) where {latₒ,Datum,Shift} =
-  LambertAzimuthalEqualArea{latₒ,Datum,Shift}(uconvert(m, x), uconvert(m, y))
-LambertAzimuthalEqualArea{latₒ,Datum,Shift}(x::Number, y::Number) where {latₒ,Datum,Shift} =
-  LambertAzimuthalEqualArea{latₒ,Datum,Shift}(addunit(x, m), addunit(y, m))
+LambertAzimuthal{latₒ,Datum,Shift}(x::M, y::M) where {latₒ,Datum,Shift,M<:Met} =
+  LambertAzimuthal{latₒ,Datum,Shift,float(M)}(x, y)
+LambertAzimuthal{latₒ,Datum,Shift}(x::Met, y::Met) where {latₒ,Datum,Shift} =
+  LambertAzimuthal{latₒ,Datum,Shift}(promote(x, y)...)
+LambertAzimuthal{latₒ,Datum,Shift}(x::Len, y::Len) where {latₒ,Datum,Shift} =
+  LambertAzimuthal{latₒ,Datum,Shift}(uconvert(m, x), uconvert(m, y))
+LambertAzimuthal{latₒ,Datum,Shift}(x::Number, y::Number) where {latₒ,Datum,Shift} =
+  LambertAzimuthal{latₒ,Datum,Shift}(addunit(x, m), addunit(y, m))
 
-LambertAzimuthalEqualArea{latₒ,Datum}(args...) where {latₒ,Datum} =
-  LambertAzimuthalEqualArea{latₒ,Datum,Shift()}(args...)
+LambertAzimuthal{latₒ,Datum}(args...) where {latₒ,Datum} = LambertAzimuthal{latₒ,Datum,Shift()}(args...)
 
-LambertAzimuthalEqualArea{latₒ}(args...) where {latₒ} = LambertAzimuthalEqualArea{latₒ,WGS84Latest}(args...)
+LambertAzimuthal{latₒ}(args...) where {latₒ} = LambertAzimuthal{latₒ,WGS84Latest}(args...)
 
 Base.convert(
-  ::Type{LambertAzimuthalEqualArea{latₒ,Datum,Shift,M}},
-  coords::LambertAzimuthalEqualArea{latₒ,Datum,Shift}
-) where {latₒ,Datum,Shift,M} = LambertAzimuthalEqualArea{latₒ,Datum,Shift,M}(coords.x, coords.y)
+  ::Type{LambertAzimuthal{latₒ,Datum,Shift,M}},
+  coords::LambertAzimuthal{latₒ,Datum,Shift}
+) where {latₒ,Datum,Shift,M} = LambertAzimuthal{latₒ,Datum,Shift,M}(coords.x, coords.y)
 
-constructor(::Type{<:LambertAzimuthalEqualArea{latₒ,Datum,Shift}}) where {latₒ,Datum,Shift} =
-  LambertAzimuthalEqualArea{latₒ,Datum,Shift}
+constructor(::Type{<:LambertAzimuthal{latₒ,Datum,Shift}}) where {latₒ,Datum,Shift} = LambertAzimuthal{latₒ,Datum,Shift}
 
-lentype(::Type{<:LambertAzimuthalEqualArea{latₒ,Datum,Shift,M}}) where {latₒ,Datum,Shift,M} = M
+lentype(::Type{<:LambertAzimuthal{latₒ,Datum,Shift,M}}) where {latₒ,Datum,Shift,M} = M
 
-==(
-  coords₁::LambertAzimuthalEqualArea{latₒ,Datum,Shift},
-  coords₂::LambertAzimuthalEqualArea{latₒ,Datum,Shift}
-) where {latₒ,Datum,Shift} = coords₁.x == coords₂.x && coords₁.y == coords₂.y
+==(coords₁::LambertAzimuthal{latₒ,Datum,Shift}, coords₂::LambertAzimuthal{latₒ,Datum,Shift}) where {latₒ,Datum,Shift} =
+  coords₁.x == coords₂.x && coords₁.y == coords₂.y
 
-isequalarea(::Type{<:LambertAzimuthalEqualArea}) = true
+isequalarea(::Type{<:LambertAzimuthal}) = true
 
 # ------------
 # CONVERSIONS
@@ -55,7 +51,7 @@ isequalarea(::Type{<:LambertAzimuthalEqualArea}) = true
 # reference code: https://github.com/OSGeo/PROJ/blob/master/src/projections/laea.cpp
 # reference formula: Section 3.6.2 of EPSG Guidance Note 7-2 (https://epsg.org/guidance-notes.html)
 
-function inbounds(::Type{<:LambertAzimuthalEqualArea{latₒ,Datum}}, λ, ϕ) where {latₒ,Datum}
+function inbounds(::Type{<:LambertAzimuthal{latₒ,Datum}}, λ, ϕ) where {latₒ,Datum}
   🌎 = ellipsoid(Datum)
   e = oftype(λ, eccentricity(🌎))
   e² = oftype(λ, eccentricity²(🌎))
@@ -76,7 +72,7 @@ function inbounds(::Type{<:LambertAzimuthalEqualArea{latₒ,Datum}}, λ, ϕ) whe
   abs(Bden) > atol(λ)
 end
 
-function formulas(::Type{<:LambertAzimuthalEqualArea{latₒ,Datum}}, ::Type{T}) where {latₒ,Datum,T}
+function formulas(::Type{<:LambertAzimuthal{latₒ,Datum}}, ::Type{T}) where {latₒ,Datum,T}
   🌎 = ellipsoid(Datum)
   e = T(eccentricity(🌎))
   e² = T(eccentricity²(🌎))
@@ -114,7 +110,7 @@ function formulas(::Type{<:LambertAzimuthalEqualArea{latₒ,Datum}}, ::Type{T}) 
   fx, fy
 end
 
-function forward(::Type{<:LambertAzimuthalEqualArea{latₒ,Datum}}, λ, ϕ) where {latₒ,Datum}
+function forward(::Type{<:LambertAzimuthal{latₒ,Datum}}, λ, ϕ) where {latₒ,Datum}
   🌎 = ellipsoid(Datum)
   e = oftype(λ, eccentricity(🌎))
   e² = oftype(λ, eccentricity²(🌎))
@@ -147,7 +143,7 @@ function forward(::Type{<:LambertAzimuthalEqualArea{latₒ,Datum}}, λ, ϕ) wher
   x, y
 end
 
-function backward(::Type{<:LambertAzimuthalEqualArea{latₒ,Datum}}, x, y) where {latₒ,Datum}
+function backward(::Type{<:LambertAzimuthal{latₒ,Datum}}, x, y) where {latₒ,Datum}
   🌎 = ellipsoid(Datum)
   e = oftype(x, eccentricity(🌎))
   e² = oftype(x, eccentricity²(🌎))
@@ -183,8 +179,8 @@ end
 # FALLBACKS
 # ----------
 
-indomain(::Type{LambertAzimuthalEqualArea{latₒ}}, coords::CRS{Datum}) where {latₒ,Datum} =
-  indomain(LambertAzimuthalEqualArea{latₒ,Datum}, coords)
+indomain(::Type{LambertAzimuthal{latₒ}}, coords::CRS{Datum}) where {latₒ,Datum} =
+  indomain(LambertAzimuthal{latₒ,Datum}, coords)
 
-Base.convert(::Type{LambertAzimuthalEqualArea{latₒ}}, coords::CRS{Datum}) where {latₒ,Datum} =
-  convert(LambertAzimuthalEqualArea{latₒ,Datum}, coords)
+Base.convert(::Type{LambertAzimuthal{latₒ}}, coords::CRS{Datum}) where {latₒ,Datum} =
+  convert(LambertAzimuthal{latₒ,Datum}, coords)

--- a/src/get.jl
+++ b/src/get.jl
@@ -45,7 +45,7 @@ end
 
 @crscode EPSG{2157} shift(TransverseMercator{0.99982,53.5°,IRENET95}, lonₒ=-8.0°, xₒ=600000.0m, yₒ=750000.0m)
 @crscode EPSG{2193} shift(TransverseMercator{0.9996,0.0°,NZGD2000}, lonₒ=173.0°, xₒ=1600000.0m, yₒ=10000000.0m)
-@crscode EPSG{3035} shift(LambertAzimuthalEqualArea{52.0°,ETRFLatest}, lonₒ=10.0°, xₒ=4321000.0m, yₒ=3210000.0m)
+@crscode EPSG{3035} shift(LambertAzimuthal{52.0°,ETRFLatest}, lonₒ=10.0°, xₒ=4321000.0m, yₒ=3210000.0m)
 @crscode EPSG{3310} shift(Albers{0.0°,34.0°,40.5°,NAD83}, lonₒ=-120.0°, yₒ=-4000000.0m)
 @crscode EPSG{3395} Mercator{WGS84Latest}
 @crscode EPSG{3857} WebMercator{WGS84Latest}

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -1635,7 +1635,7 @@
       @inferred convert(LatLon, c2)
     end
 
-    @testset "LatLon <> LambertAzimuthalEqualArea" begin
+    @testset "LatLon <> LambertAzimuthal" begin
       # forward tested against Proj.Transformation("""
       # proj=pipeline
       # step proj=axisswap order=2,1
@@ -1648,7 +1648,7 @@
       # step proj=unitconvert xy_in=rad xy_out=deg
       # step proj=axisswap order=2,1
       # """)
-      LAEA = LambertAzimuthalEqualArea{15.0°}
+      LAEA = LambertAzimuthal{15.0°}
       c1 = LatLon(T(45), T(90))
       c2 = convert(LAEA, c1)
       @test isapprox(c2, LAEA(T(5.879661317585923e6), T(5.643833348229035e6)))
@@ -1674,7 +1674,7 @@
       @test isapprox(c3, c1)
 
       # invert central coordinates
-      ShiftedLAEA = CoordRefSystems.shift(LambertAzimuthalEqualArea{30.0°,WGS84Latest}, lonₒ=60°)
+      ShiftedLAEA = CoordRefSystems.shift(LambertAzimuthal{30.0°,WGS84Latest}, lonₒ=60°)
       c1 = LatLon(T(30), T(60))
       c2 = convert(ShiftedLAEA, c1)
       @test isapprox(c2, ShiftedLAEA(T(0), T(0)))
@@ -1847,10 +1847,10 @@
 
       # WGS84 (G2296) to ETRF2020
       c1 = LatLon{WGS84{2296}}(T(45), T(90))
-      c2 = convert(LambertAzimuthalEqualArea{52.0°,ETRF{2020}}, c1)
-      @test isapprox(c2, LambertAzimuthalEqualArea{52.0°,ETRF{2020}}(T(5122666.32147123), T(3145786.6707593063)))
+      c2 = convert(LambertAzimuthal{52.0°,ETRF{2020}}, c1)
+      @test isapprox(c2, LambertAzimuthal{52.0°,ETRF{2020}}(T(5122666.32147123), T(3145786.6707593063)))
 
-      c1 = LambertAzimuthalEqualArea{52.0°,ETRF{2020}}(T(5122666.32147123), T(3145786.6707593063))
+      c1 = LambertAzimuthal{52.0°,ETRF{2020}}(T(5122666.32147123), T(3145786.6707593063))
       c2 = convert(LatLon{WGS84{2296}}, c1)
       @test isapprox(c2, LatLon{WGS84{2296}}(T(45), T(90)))
 

--- a/test/crs/domains.jl
+++ b/test/crs/domains.jl
@@ -110,7 +110,7 @@
           @test isclose(c3, c1)
         end
       end
-    elseif C <: LambertAzimuthalEqualArea
+    elseif C <: LambertAzimuthal
       # coordinates at the singularity of the projection (lat ≈ ±90) cannot be inverted
       # Float32 inversion is not very accurate
       if T === Float32

--- a/test/get.jl
+++ b/test/get.jl
@@ -10,7 +10,7 @@
   )
   gettest(
     EPSG{3035},
-    CoordRefSystems.shift(LambertAzimuthalEqualArea{52.0°,ETRFLatest}, lonₒ=10.0°, xₒ=4321000.0m, yₒ=3210000.0m)
+    CoordRefSystems.shift(LambertAzimuthal{52.0°,ETRFLatest}, lonₒ=10.0°, xₒ=4321000.0m, yₒ=3210000.0m)
   )
   gettest(EPSG{3310}, CoordRefSystems.shift(Albers{0.0°,34.0°,40.5°,NAD83}, lonₒ=-120.0°, yₒ=-4000000.0m))
   gettest(EPSG{3395}, Mercator{WGS84Latest})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ projected = [
   TransverseMercator{0.9996,0.0°},
   Albers{23.0°,29.5°,45.0°},
   Sinusoidal,
-  LambertAzimuthalEqualArea{15.0°},
+  LambertAzimuthal{15.0°},
   EqualEarth
 ]
 


### PR DESCRIPTION
The `EqualArea` suffix is already modeled by the `isequalarea` trait.