### PR TITLE
Add NAD27 <> WGS84 conversion

### DIFF
--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -40,7 +40,7 @@ include("transforms/sequential.jl")
 @identity NZGD2000 WGS84
 
 # https://epsg.org/transformation_1170/NAD27-to-WGS-84-1.html
-@geoctranslation NAD27 WGS84 (δx=-3.0, δy=142, δz=183)
+@geoctranslation NAD27 WGS84 (δx=-3.0, δy=142.0, δz=183.0)
 
 # https://epsg.org/transformation_1130/Carthage-to-WGS-84-1.html
 @geoctranslation Carthage WGS84 (δx=-263.0, δy=6.0, δz=431.0)

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -39,6 +39,9 @@ include("transforms/sequential.jl")
 # https://epsg.org/transformation_1565/NZGD2000-to-WGS-84-1.html
 @identity NZGD2000 WGS84
 
+# https://epsg.org/transformation_1170/NAD27-to-WGS-84-1.html
+@geoctranslation NAD27 WGS84 (δx=-3.0, δy=142, δz=183)
+
 # https://epsg.org/transformation_1130/Carthage-to-WGS-84-1.html
 @geoctranslation Carthage WGS84 (δx=-263.0, δy=6.0, δz=431.0)
 

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -256,6 +256,11 @@
       @inferred convert(Cartesian{ITRF{2008}}, c1)
       @inferred convert(Cartesian{ITRF{2020}}, c2)
 
+      # NAD27 to WGS84 (2296)
+      c1 = Cartesian{NAD27}(T(0), T(0), T(0))
+      c2 = convert(Cartesian{WGS84{2296}}, c1)
+      @test isapprox(c2, Cartesian{WGS84{2296}}(T(-3.0), T(142.0), T(183.0)))
+
       # other basic CRS
       c1 = Cylindrical{WGS84{1762}}(T(0), T(0), T(0))
       c2 = convert(Cylindrical{ITRF{2008}}, c1)
@@ -701,6 +706,13 @@
       c2 = convert(LatLon{ITRF{2020}}, c1)
       @test isapprox(c2, LatLon{ITRF{2020}}(T(35), T(45)))
       c3 = convert(LatLon{WGS84{2296}}, c2)
+      @test isapprox(c3, c1)
+
+      # NAD27 to WGS84
+      c1 = LatLon{NAD27}(T(30), T(40))
+      c2 = convert(LatLon{WGS84{2296}}, c1)
+      @test isapprox(c2, LatLon{WGS84{2296}}(T(29.999172812878406), T(40.00114734092287)))
+      c3 = convert(LatLon{NAD27}, c2)
       @test isapprox(c3, c1)
 
       # Carthage to WGS84


### PR DESCRIPTION
The title of the PR is self-explanatory.

@tcarion this conversion rule might be useful to you as it allows converting any CRS from WGS84 to NAD27 datum.

There are different variants for these datum conversions, but at the moment we always pick the first variant.

Please let us know if you have a better suggestion for variant selection.