### PR TITLE
Simplifly `isapprox`

### DIFF
--- a/src/crs.jl
+++ b/src/crs.jl
@@ -136,9 +136,9 @@ function Base.isapprox(coords₁::CRS, coords₂::CRS; kwargs...)
 end
 
 function Base.isapprox(coords₁::C, coords₂::C; kwargs...) where {C<:CRS}
-  all(1:nfields(coords₁)) do i
-    c₁ = getfield(coords₁, i)
-    c₂ = getfield(coords₂, i)
+  vals₁ = values(coords₁)
+  vals₂ = values(coords₂)
+  all(zip(vals₁, vals₂)) do (c₁, c₂)
     isapprox(c₁, c₂; rtol=rtol(c₁), atol=atol(c₁), kwargs...)
   end
 end

--- a/src/crs/basic/cartesian.jl
+++ b/src/crs/basic/cartesian.jl
@@ -121,16 +121,6 @@ lentype(::Type{<:Cartesian{Datum,N,L}}) where {Datum,N,L} = L
 
 ==(coords₁::Cartesian{Datum,N}, coords₂::Cartesian{Datum,N}) where {Datum,N} = _coords(coords₁) == _coords(coords₂)
 
-function Base.isapprox(coords₁::C, coords₂::C; kwargs...) where {C<:Cartesian}
-  tuple₁ = _coords(coords₁)
-  tuple₂ = _coords(coords₂)
-  all(1:length(tuple₁)) do i
-    c₁ = getfield(tuple₁, i)
-    c₂ = getfield(tuple₂, i)
-    isapprox(c₁, c₂; rtol=rtol(c₁), atol=atol(c₁), kwargs...)
-  end
-end
-
 Random.rand(rng::Random.AbstractRNG, ::Type{Cartesian{Datum,N}}) where {Datum,N} =
   Cartesian{Datum}(ntuple(i -> rand(rng), N)...)
 


### PR DESCRIPTION
This PR also makes `isapprox` faster for CRS types with mixed units.
# Benchmarks
## Setup
```julia
julia> using CoordRefSystems

julia> using BenchmarkTools

julia> p1 = Polar(1.0, 1.0);

julia> p2 = Polar(1.0 + eps(), 1.0 + eps());

julia> s1 = Spherical(1.0, 1.0, 1.0);

julia> s2 = Spherical(1.0 + eps(), 1.0 + eps(), 1.0 + eps());

julia> c1 = Cartesian(1.0, 1.0, 1.0);

julia> c2 = Cartesian(1.0 + eps(), 1.0 + eps(), 1.0 + eps());

julia> ll1 = LatLon(1.0, 1.0);

julia> ll2 = LatLon(1.0 + eps(), 1.0 + eps());
```

## PR
```julia
julia> @benchmark isapprox($p1, $p2)
BenchmarkTools.Trial: 10000 samples with 858 evaluations per sample.
 Range (min … max):  135.437 ns …   7.534 μs  ┊ GC (min … max): 0.00% … 97.64%
 Time  (median):     141.528 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   158.225 ns ± 253.616 ns  ┊ GC (mean ± σ):  8.40% ±  5.11%

   ▄▇▇▅▇█▆▄▄▃▂   ▁▁                        ▁▂▂▂▁                ▂
  ▇████████████████████▇▇▇▇▇▆▇▆▅▅▆▆▄▄▅▅▅▆▆▇███████▆▆▅▆▅▄▆▆▅▅▄▄▄ █
  135 ns        Histogram: log(frequency) by time        196 ns <

 Memory estimate: 160 bytes, allocs estimate: 6.

julia> @benchmark isapprox($s1, $s2)
BenchmarkTools.Trial: 10000 samples with 421 evaluations per sample.
 Range (min … max):  232.171 ns …  19.479 μs  ┊ GC (min … max): 0.00% … 98.21%
 Time  (median):     245.711 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   277.837 ns ± 492.844 ns  ┊ GC (mean ± σ):  7.67% ±  4.34%

   ▄▆▆█▆▇▇▄▃▂                  ▁▁▂▂▁▂▃▁                         ▂
  ▇████████████▇▇▇▇██▇█▇▇▆▆▅▅▆▇█████████▇█▆▅▅▅▆▆▄▆▅▆▅▄▄▃▄▄▅▅▄▃▆ █
  232 ns        Histogram: log(frequency) by time        383 ns <

 Memory estimate: 288 bytes, allocs estimate: 11.

julia> @benchmark isapprox($c1, $c2)
BenchmarkTools.Trial: 10000 samples with 999 evaluations per sample.
 Range (min … max):   8.171 ns … 43.279 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     10.056 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.140 ns ±  1.668 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

              ▁  ▂ ▆ █ ▄                                       
  ▂▂▃▂▅▂▅▂▄▃▆▄█▅▆█▄█▄█▄█▃▅▃▃▃▂▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▁▂ ▃
  8.17 ns         Histogram: frequency by time        14.6 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark isapprox($ll1, $ll2)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  6.370 ns … 21.941 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     7.006 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.078 ns ±  0.641 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █           ▆     ▁     ▁                                   
  █▆▂▁▃▂▄▂▁▂▂▂█▃▂▄▃▃█▂▂▁▃▄█▂▂▂▂▅▇▂▁▁▂▄▅▂▁▁▂▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  6.37 ns        Histogram: frequency by time        8.76 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
 ```
 ## main
 ```julia
 julia> @benchmark isapprox($p1, $p2)
BenchmarkTools.Trial: 10000 samples with 190 evaluations per sample.
 Range (min … max):  539.163 ns …  55.112 μs  ┊ GC (min … max): 0.00% … 98.66%
 Time  (median):     559.218 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   617.400 ns ± 932.908 ns  ┊ GC (mean ± σ):  6.34% ±  4.68%

  ▆██▇▆▃▂   ▁   ▂▃▃▂▁                                           ▂
  ████████▇▇█████████▇▆▅▇▇▇▇▆▆▆▆▆▅▅▄▄▆▅▅▅▄▆▅▄▅▂▄▃▃▄▄▃▄▄▄▂▃▂▄▂▄▄ █
  539 ns        Histogram: log(frequency) by time       1.01 μs <

 Memory estimate: 448 bytes, allocs estimate: 20.

julia> @benchmark isapprox($s1, $s2)
BenchmarkTools.Trial: 10000 samples with 95 evaluations per sample.
 Range (min … max):  801.432 ns … 88.997 μs  ┊ GC (min … max): 0.00% … 98.79%
 Time  (median):     829.042 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   905.849 ns ±  1.679 μs  ┊ GC (mean ± σ):  5.01% ±  2.77%

  ▅▆▆█▇▄▃▃▂▁         ▁▂▂▂▃▃▂▂▂▂                                ▂
  ███████████▇▇▆▅▅▅▄▆████████████▇▇▆▅▅▅▁▆▄▄▄▆▆▅▆▆▆▅▆▆▆▆▆▄▅▄▃▅▅ █
  801 ns        Histogram: log(frequency) by time      1.25 μs <

 Memory estimate: 672 bytes, allocs estimate: 30.

julia> @benchmark isapprox($c1, $c2)
BenchmarkTools.Trial: 10000 samples with 999 evaluations per sample.
 Range (min … max):   8.870 ns … 34.186 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     10.314 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.517 ns ±  1.604 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

           ▂  ▄  ▄  █  ▇  ▇  ▄  ▃                              
  ▅▃▃▆▅▃▄▆▄█▅▄█▃▄█▃▃█▃▃█▂▃█▂▂█▂▂█▂▂█▂▂▆▂▂▄▂▂▃▂▂▂▂▂▂▂▁▁▂▂▂▂▂▂▂ ▃
  8.87 ns         Histogram: frequency by time        13.5 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark isapprox($ll1, $ll2)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  6.371 ns … 32.510 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     7.115 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.147 ns ±  0.778 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █             ▆▁     ▇▅             ▁      ▆                
  █▇▂▁▂▂▂▇▄█▅▄▁▁██▂▂▂▁▂██▂▄▂▂▁██▁▁▂▁▂▅█▂▁▁▁▁▆█▂▁▁▁▁▂▃▂▁▂▁▂▁▆ ▃
  6.37 ns        Histogram: frequency by time        8.35 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
 ```