### PR TITLE
Add EPSG 2039 

### DIFF
--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -67,6 +67,7 @@ export
   ISN93,
   ISN2004,
   ISN2016,
+  Israel1993,
   Lisbon1890,
   Lisbon1937,
   NAD27,

--- a/src/datums.jl
+++ b/src/datums.jl
@@ -540,3 +540,13 @@ See <https://epsg.org/datum_6674/Sistema-de-Referencia-Geocentrico-para-las-Amer
 abstract type SIRGAS2000 <: Datum end
 
 ellipsoid(::Type{SIRGAS2000}) = GRS80🌎
+
+"""
+    Israel1993
+
+See <https://epsg.org/datum_6141/Israel-1993.html>
+"""
+
+abstract type Israel1993 <: Datum end
+
+ellipsoid(::Type{Israel1993}) = GRS80🌎

--- a/src/datums.jl
+++ b/src/datums.jl
@@ -361,6 +361,16 @@ abstract type ISN2016 <: Datum end
 ellipsoid(::Type{ISN2016}) = GRS80🌎
 
 """
+    Israel1993
+
+See <https://epsg.org/datum_6141/Israel-1993.html>
+"""
+
+abstract type Israel1993 <: Datum end
+
+ellipsoid(::Type{Israel1993}) = GRS80🌎
+
+"""
     Lisbon1890
 
 Lisbon 1890 datum.
@@ -541,12 +551,3 @@ abstract type SIRGAS2000 <: Datum end
 
 ellipsoid(::Type{SIRGAS2000}) = GRS80🌎
 
-"""
-    Israel1993
-
-See <https://epsg.org/datum_6141/Israel-1993.html>
-"""
-
-abstract type Israel1993 <: Datum end
-
-ellipsoid(::Type{Israel1993}) = GRS80🌎

--- a/src/get.jl
+++ b/src/get.jl
@@ -43,6 +43,7 @@ end
 # IMPLEMENTATIONS
 # ----------------
 
+@crscode EPSG{2039} shift(TransverseMercator{1.0000067,31.734394°,Israel1993}, lonₒ=35.204517°, xₒ=219529.584m, yₒ=626907.39m)
 @crscode EPSG{2157} shift(TransverseMercator{0.99982,53.5°,IRENET95}, lonₒ=-8.0°, xₒ=600000.0m, yₒ=750000.0m)
 @crscode EPSG{2193} shift(TransverseMercator{0.9996,0.0°,NZGD2000}, lonₒ=173.0°, xₒ=1600000.0m, yₒ=10000000.0m)
 @crscode EPSG{3035} shift(LambertAzimuthal{52.0°,ETRFLatest}, lonₒ=10.0°, xₒ=4321000.0m, yₒ=3210000.0m)
@@ -107,7 +108,6 @@ end
 @crscode ESRI{102035} Orthographic{SphericalMode,90°,WGS84Latest}
 @crscode ESRI{102037} Orthographic{SphericalMode,-90°,WGS84Latest}
 @crscode EPSG{2180} shift(TransverseMercator{0.9993,0.0°,NoDatum}, lonₒ=19.0°, xₒ=500000.0m, yₒ=-5300000.0m)
-@crscode EPSG{2039} shift(TransverseMercator{1.0000067,31.734394°,Israel1993}, lonₒ=35.204517°, xₒ=219529.584m, yₒ=626907.39m)
 
 for zone in 1:60
   NorthCode = 32600 + zone

--- a/src/get.jl
+++ b/src/get.jl
@@ -107,6 +107,7 @@ end
 @crscode ESRI{102035} Orthographic{SphericalMode,90°,WGS84Latest}
 @crscode ESRI{102037} Orthographic{SphericalMode,-90°,WGS84Latest}
 @crscode EPSG{2180} shift(TransverseMercator{0.9993,0.0°,NoDatum}, lonₒ=19.0°, xₒ=500000.0m, yₒ=-5300000.0m)
+@crscode EPSG{2039} shift(TransverseMercator{1.0000067,31.734394°,Israel1993}, lonₒ=35.204517°, xₒ=219529.584m, yₒ=626907.39m)
 
 for zone in 1:60
   NorthCode = 32600 + zone

--- a/test/datums.jl
+++ b/test/datums.jl
@@ -117,4 +117,6 @@
   @test ellipsoid(SAD96) === CoordRefSystems.GRS67Modified🌎
 
   @test ellipsoid(SIRGAS2000) === CoordRefSystems.GRS80🌎
+
+  @test ellipsoid(Israel1993) === CoordRefSystems.GRS80🌎
 end

--- a/test/datums.jl
+++ b/test/datums.jl
@@ -84,6 +84,8 @@
 
   @test ellipsoid(ISN2016) === CoordRefSystems.GRS80🌎
 
+  @test ellipsoid(Israel1993) === CoordRefSystems.GRS80🌎
+
   @test ellipsoid(Lisbon1890) === CoordRefSystems.Bessel🌎
 
   @test ellipsoid(Lisbon1937) === CoordRefSystems.Intl🌎
@@ -118,5 +120,4 @@
 
   @test ellipsoid(SIRGAS2000) === CoordRefSystems.GRS80🌎
 
-  @test ellipsoid(Israel1993) === CoordRefSystems.GRS80🌎
 end

--- a/test/get.jl
+++ b/test/get.jl
@@ -89,6 +89,14 @@
   gettest(ESRI{54042}, WinkelTripel{WGS84Latest})
   gettest(ESRI{102035}, CoordRefSystems.Orthographic{CoordRefSystems.SphericalMode,90°,WGS84Latest})
   gettest(ESRI{102037}, CoordRefSystems.Orthographic{CoordRefSystems.SphericalMode,-90°,WGS84Latest})
+  gettest(EPSG{31370},
+    CoordRefSystems.shift(
+      TransverseMercator{1.0000067,31.734394°,Israel1993}, 
+      lonₒ=35.204517°,
+      xₒ=219529.584m,
+      yₒ=626907.39m
+    )
+  )
 
   for zone in 1:60
     NorthCode = 32600 + zone

--- a/test/get.jl
+++ b/test/get.jl
@@ -1,5 +1,13 @@
 @testset "get" begin
   # EPSG/ESRI code
+  gettest(EPSG{2039},
+    CoordRefSystems.shift(
+      TransverseMercator{1.0000067,31.734394°,Israel1993},
+      lonₒ=35.204517°,
+      xₒ=219529.584m,
+      yₒ=626907.39m
+    )
+  )
   gettest(
     EPSG{2157},
     CoordRefSystems.shift(TransverseMercator{0.99982,53.5°,IRENET95}, lonₒ=-8.0°, xₒ=600000.0m, yₒ=750000.0m)
@@ -89,14 +97,6 @@
   gettest(ESRI{54042}, WinkelTripel{WGS84Latest})
   gettest(ESRI{102035}, CoordRefSystems.Orthographic{CoordRefSystems.SphericalMode,90°,WGS84Latest})
   gettest(ESRI{102037}, CoordRefSystems.Orthographic{CoordRefSystems.SphericalMode,-90°,WGS84Latest})
-  gettest(EPSG{31370},
-    CoordRefSystems.shift(
-      TransverseMercator{1.0000067,31.734394°,Israel1993}, 
-      lonₒ=35.204517°,
-      xₒ=219529.584m,
-      yₒ=626907.39m
-    )
-  )
 
   for zone in 1:60
     NorthCode = 32600 + zone


### PR DESCRIPTION
I've attempted to follow the instructions [here](https://discourse.julialang.org/t/esri-code-for-british-national-grid-not-known-by-geoio/117641) as well as examples from the existing code. 

The EPSG and datum I'm adding are described [here](https://epsg.org/crs_2039/Israel-1993-Israeli-TM-Grid.html) and [here](https://epsg.org/datum_6141/Israel-1993.html) respectively. 

Please let me know what changes (if any) you'd like to see before this is merge-ready.