### PR TITLE
Fix EPSG{2180}

### DIFF
--- a/src/get.jl
+++ b/src/get.jl
@@ -44,6 +44,7 @@ end
 # ----------------
 
 @crscode EPSG{2157} shift(TransverseMercator{0.99982,53.5°,IRENET95}, lonₒ=-8.0°, xₒ=600000.0m, yₒ=750000.0m)
+@crscode EPSG{2180} shift(TransverseMercator{0.9993,0.0°,ETRF{2000}}, lonₒ=19.0°, xₒ=500000.0m, yₒ=-5300000.0m)
 @crscode EPSG{2193} shift(TransverseMercator{0.9996,0.0°,NZGD2000}, lonₒ=173.0°, xₒ=1600000.0m, yₒ=10000000.0m)
 @crscode EPSG{3035} shift(LambertAzimuthal{52.0°,ETRFLatest}, lonₒ=10.0°, xₒ=4321000.0m, yₒ=3210000.0m)
 @crscode EPSG{3310} shift(Albers{0.0°,34.0°,40.5°,NAD83}, lonₒ=-120.0°, yₒ=-4000000.0m)
@@ -106,7 +107,6 @@ end
 @crscode ESRI{54042} WinkelTripel{WGS84Latest}
 @crscode ESRI{102035} Orthographic{SphericalMode,90°,WGS84Latest}
 @crscode ESRI{102037} Orthographic{SphericalMode,-90°,WGS84Latest}
-@crscode EPSG{2180} shift(TransverseMercator{0.9993,0.0°,NoDatum}, lonₒ=19.0°, xₒ=500000.0m, yₒ=-5300000.0m)
 
 for zone in 1:60
   NorthCode = 32600 + zone

--- a/test/get.jl
+++ b/test/get.jl
@@ -5,6 +5,10 @@
     CoordRefSystems.shift(TransverseMercator{0.99982,53.5°,IRENET95}, lonₒ=-8.0°, xₒ=600000.0m, yₒ=750000.0m)
   )
   gettest(
+    EPSG{2180},
+    CoordRefSystems.shift(TransverseMercator{0.9993,0.0°,ETRF{2000}}, lonₒ=19.0°, xₒ=500000.0m, yₒ=-5300000.0m)
+  )
+  gettest(
     EPSG{2193},
     CoordRefSystems.shift(TransverseMercator{0.9996,0.0°,NZGD2000}, lonₒ=173.0°, xₒ=1600000.0m, yₒ=10000000.0m)
   )
@@ -68,10 +72,6 @@
   gettest(
     EPSG{29903},
     CoordRefSystems.shift(TransverseMercator{1.000035,53.5°,Ire65}, lonₒ=-8.0°, xₒ=200000.0m, yₒ=250000.0m)
-  )
-  gettest(
-    EPSG{2180},
-    CoordRefSystems.shift(TransverseMercator{0.9993,0.0°,NoDatum}, lonₒ=19.0°, xₒ=500000.0m, yₒ=-5300000.0m)
   )
   gettest(
     EPSG{31370},


### PR DESCRIPTION
@souma4 could you please confirm this was a bug? I noticed that you used `NoDatum`, but the EPSG database points to ETRF{2000}: https://epsg.org/crs_2180/ETRF2000-PL-CS92.html