### PR TITLE
Add EPSG:29902

### DIFF
--- a/src/get.jl
+++ b/src/get.jl
@@ -43,6 +43,27 @@ end
 # IMPLEMENTATIONS
 # ----------------
 
+# To map a EPSG{code} to a CRS type, please go to
+# https://epsg.org/search/by-name and type the code
+# in the search box.
+#
+# Check the CRSs tab of the result and click on the
+# desired entry in the table. You will be redirected
+# to a page with clickable items.
+#
+# You need to find the ellipsoid inside the datum item
+# and the conversion parameters of the projection in case
+# of projected coordinates.
+#
+# Double check the parameters stored in the EPSG database
+# using the `projinfo` utility that is shipped with PROJ:
+#
+# shell> projinfo EPSG:5070
+#
+# If the sign of some parameter differs, for example lon_0=8
+# in the EPSG database and lon_0=-8 in the projinfo output,
+# please use the projinfo output.
+
 @crscode EPSG{2039} shift(
   TransverseMercator{1.0000067,31.734394°,Israel1993},
   lonₒ=35.204517°,
@@ -97,6 +118,11 @@ end
 @crscode EPSG{25832} shift(TransverseMercator{0.9996,0.0°,ETRFLatest}, lonₒ=9.0°, xₒ=500000.0m, yₒ=0.0m)
 @crscode EPSG{27700} shift(TransverseMercator{0.9996012717,49.0°,OSGB36}, lonₒ=-2.0°, xₒ=400000.0m, yₒ=-100000.0m)
 @crscode EPSG{28355} shift(TransverseMercator{0.9996,0.0°,GDA94}, lonₒ=147.0°, xₒ=500000.0m, yₒ=10000000.0m)
+# For EPSG:29902, the lat/lon projection parameters are given in sexagesimal DMS in the EPSG database.
+# To avoid unit conversion, the literal parameters are those obtained with the PROJ command `projinfo EPSG:29902`.
+@crscode EPSG{29902} shift(TransverseMercator{1.000035,53.5°,Ire65}, lonₒ=-8.0°, xₒ=200000.0m, yₒ=250000.0m)
+# For EPSG:29903, the lat/lon projection parameters are given in sexagesimal DMS in the EPSG database.
+# To avoid unit conversion, the literal parameters are those obtained with the PROJ command `projinfo EPSG:29903`.
 @crscode EPSG{29903} shift(TransverseMercator{1.000035,53.5°,Ire65}, lonₒ=-8.0°, xₒ=200000.0m, yₒ=250000.0m)
 # For EPSG:31370, the lat/lon projection parameters are given in sexagesimal DMS in the EPSG database.
 # To avoid unit conversion, the literal parameters are those obtained with the PROJ command `projinfo EPSG:31370`.

--- a/test/get.jl
+++ b/test/get.jl
@@ -79,6 +79,10 @@
     CoordRefSystems.shift(TransverseMercator{0.9996,0.0°,GDA94}, lonₒ=147.0°, xₒ=500000.0m, yₒ=10000000.0m)
   )
   gettest(
+    EPSG{29902},
+    CoordRefSystems.shift(TransverseMercator{1.000035,53.5°,Ire65}, lonₒ=-8.0°, xₒ=200000.0m, yₒ=250000.0m)
+  )
+  gettest(
     EPSG{29903},
     CoordRefSystems.shift(TransverseMercator{1.000035,53.5°,Ire65}, lonₒ=-8.0°, xₒ=200000.0m, yₒ=250000.0m)
   )


### PR DESCRIPTION
Fix #318 

@eliascarv apparently we can have two codes mapping to the same CRS type. Do you have suggestions on how we could adjust the `crscode` macro to accept a list of codes followed by a single CRS?

```julia
@crscode EPSG{22902} EPSG{22903} CRS
```

We will also need to adjust some basic logic regarding the extraction of code from a given CRS. Now that multiple codes are mapped to a CRS type, we need to introduce a rule to retrieve one of the codes. Probably the first code in the list should be selected.