### PR TITLE
add EPSG:4236

### DIFF
--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -61,6 +61,7 @@ export
   GGRS87,
   GRS80S,
   Hermannskogel,
+  HuTzuShan1950,
   IGS20,
   Ire65,
   IRENET95,

--- a/src/datums.jl
+++ b/src/datums.jl
@@ -181,15 +181,6 @@ epoch(::Type{NAD83CSRS{7}}) = 2010.0
 epoch(::Type{NAD83CSRS{8}}) = 2010.0
 
 """
-    HuTzuShan1950
-
-Hu Tzu Shan 1950 datum
-"""
-abstract type HuTzuShan1950 <: Datum end
-
-ellipsoid(::Type{HuTzuShan1950}) = Intl🌎
-
-"""
     Aratu
 
 Aratu datum.
@@ -308,6 +299,15 @@ Hermannskogel datum.
 abstract type Hermannskogel <: Datum end
 
 ellipsoid(::Type{Hermannskogel}) = Bessel🌎
+
+"""
+    HuTzuShan1950
+
+Hu Tzu Shan 1950 datum
+"""
+abstract type HuTzuShan1950 <: Datum end
+
+ellipsoid(::Type{HuTzuShan1950}) = Intl🌎
 
 """
     IGS20

--- a/src/datums.jl
+++ b/src/datums.jl
@@ -181,6 +181,15 @@ epoch(::Type{NAD83CSRS{7}}) = 2010.0
 epoch(::Type{NAD83CSRS{8}}) = 2010.0
 
 """
+    HuTzuShan1950
+
+Hu Tzu Shan 1950 datum
+"""
+abstract type HuTzuShan1950 <: Datum end
+
+ellipsoid(::Type{HuTzuShan1950}) = Intl🌎
+
+"""
     Aratu
 
 Aratu datum.

--- a/src/get.jl
+++ b/src/get.jl
@@ -89,7 +89,7 @@ end
 @crscodes LatLon{Aratu} EPSG{4208}
 @crscodes LatLon{ED50} EPSG{4230}
 @crscodes LatLon{ED87} EPSG{4231}
-@crscodes LatLon{WGS84} EPSG{4236}
+@crscodes LatLong{Intl} EPSG{4236}
 @crscodes LatLon{NAD27} EPSG{4267}
 @crscodes LatLon{NAD83} EPSG{4269}
 @crscodes LatLon{Datum73} EPSG{4274}

--- a/src/get.jl
+++ b/src/get.jl
@@ -89,7 +89,7 @@ end
 @crscodes LatLon{Aratu} EPSG{4208}
 @crscodes LatLon{ED50} EPSG{4230}
 @crscodes LatLon{ED87} EPSG{4231}
-@crscodes LatLong{Intl} EPSG{4236}
+@crscodes LatLon{HuTzuShan1950} EPSG{4236}
 @crscodes LatLon{NAD27} EPSG{4267}
 @crscodes LatLon{NAD83} EPSG{4269}
 @crscodes LatLon{Datum73} EPSG{4274}

--- a/src/get.jl
+++ b/src/get.jl
@@ -89,6 +89,7 @@ end
 @crscodes LatLon{Aratu} EPSG{4208}
 @crscodes LatLon{ED50} EPSG{4230}
 @crscodes LatLon{ED87} EPSG{4231}
+@crscodes LatLon{WGS84} EPSG{4236}
 @crscodes LatLon{NAD27} EPSG{4267}
 @crscodes LatLon{NAD83} EPSG{4269}
 @crscodes LatLon{Datum73} EPSG{4274}

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -91,7 +91,7 @@ include("transforms/sequential.jl")
 @helmert WGS84{2139} WGS84{2296} (δx=2.6e-3, δy=5.4e-3, δz=-0.9e-3, θx=-0.01e-3, θy=-0.07e-3, s=0.06e-3)
 
 # https://epsg.org/transformation_1152/Hu-Tzu-Shan-1950-to-WGS-84-1.html
-@helmert EPSG{4236} WSG84 (δx=-637, δy=-549, δz=-203)
+@helmert HuTzuShan1950 WGS84 (δx=-637, δy=-549, δz=-203)
 
 # https://epsg.org/transformation_15929/BD72-to-WGS-84-3.html
 @helmert BD72 WGS84 (δx=-106.8686, δy=52.2978, δz=-103.7239, θx=-0.3366, θy=0.457, θz=-1.8422, s=-1.2747)

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -60,6 +60,9 @@ include("transforms/sequential.jl")
 # https://github.com/OSGeo/PROJ/blob/master/src/datums.cpp
 @helmert Hermannskogel WGS84 (δx=577.326, δy=90.129, δz=463.919, θx=-5.137, θy=-1.474, θz=-5.297, s=2.4232)
 
+# https://epsg.org/transformation_1152/Hu-Tzu-Shan-1950-to-WGS-84-1.html
+@helmert HuTzuShan1950 WGS84 (δx=-637, δy=-549, δz=-203)
+
 # https://github.com/OSGeo/PROJ/blob/master/src/datums.cpp
 @helmert Ire65 WGS84 (δx=482.530, δy=-130.596, δz=564.557, θx=1.042, θy=0.214, θz=0.631, s=8.15)
 
@@ -89,9 +92,6 @@ include("transforms/sequential.jl")
 
 # https://epsg.org/transformation_10607/WGS-84-G2139-to-WGS-84-G2296-1.html
 @helmert WGS84{2139} WGS84{2296} (δx=2.6e-3, δy=5.4e-3, δz=-0.9e-3, θx=-0.01e-3, θy=-0.07e-3, s=0.06e-3)
-
-# https://epsg.org/transformation_1152/Hu-Tzu-Shan-1950-to-WGS-84-1.html
-@helmert HuTzuShan1950 WGS84 (δx=-637, δy=-549, δz=-203)
 
 # https://epsg.org/transformation_15929/BD72-to-WGS-84-3.html
 @helmert BD72 WGS84 (δx=-106.8686, δy=52.2978, δz=-103.7239, θx=-0.3366, θy=0.457, θz=-1.8422, s=-1.2747)

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -60,9 +60,6 @@ include("transforms/sequential.jl")
 # https://github.com/OSGeo/PROJ/blob/master/src/datums.cpp
 @helmert Hermannskogel WGS84 (δx=577.326, δy=90.129, δz=463.919, θx=-5.137, θy=-1.474, θz=-5.297, s=2.4232)
 
-# https://epsg.org/transformation_1152/Hu-Tzu-Shan-1950-to-WGS-84-1.html
-@helmert HuTzuShan1950 WGS84 (δx=-637, δy=-549, δz=-203)
-
 # https://github.com/OSGeo/PROJ/blob/master/src/datums.cpp
 @helmert Ire65 WGS84 (δx=482.530, δy=-130.596, δz=564.557, θx=1.042, θy=0.214, θz=0.631, s=8.15)
 
@@ -92,6 +89,9 @@ include("transforms/sequential.jl")
 
 # https://epsg.org/transformation_10607/WGS-84-G2139-to-WGS-84-G2296-1.html
 @helmert WGS84{2139} WGS84{2296} (δx=2.6e-3, δy=5.4e-3, δz=-0.9e-3, θx=-0.01e-3, θy=-0.07e-3, s=0.06e-3)
+
+# https://epsg.org/transformation_1152/Hu-Tzu-Shan-1950-to-WGS-84-1.html
+@helmert HuTzuShan1950 WGS84 (δx=-637, δy=-549, δz=-203)
 
 # https://epsg.org/transformation_15929/BD72-to-WGS-84-3.html
 @helmert BD72 WGS84 (δx=-106.8686, δy=52.2978, δz=-103.7239, θx=-0.3366, θy=0.457, θz=-1.8422, s=-1.2747)

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -90,6 +90,9 @@ include("transforms/sequential.jl")
 # https://epsg.org/transformation_10607/WGS-84-G2139-to-WGS-84-G2296-1.html
 @helmert WGS84{2139} WGS84{2296} (δx=2.6e-3, δy=5.4e-3, δz=-0.9e-3, θx=-0.01e-3, θy=-0.07e-3, s=0.06e-3)
 
+# https://epsg.org/transformation_1152/Hu-Tzu-Shan-1950-to-WGS-84-1.html
+@helmert EPSG{4236} WSG84 (δx=-637, δy=-549, δz=-203)
+
 # https://epsg.org/transformation_15929/BD72-to-WGS-84-3.html
 @helmert BD72 WGS84 (δx=-106.8686, δy=52.2978, δz=-103.7239, θx=-0.3366, θy=0.457, θz=-1.8422, s=-1.2747)
 

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -57,6 +57,9 @@ include("transforms/sequential.jl")
 # https://epsg.org/transformation_1864/SAD69-to-WGS-84-1.html
 @geoctranslation SAD69 WGS84 (δx=-57.0, δy=1.0, δz=-41.0)
 
+# https://epsg.org/transformation_1152/Hu-Tzu-Shan-1950-to-WGS-84-1.html
+@geoctranslation HuTzuShan1950 WGS84 (δx=-637, δy=-549, δz=-203)
+
 # https://github.com/OSGeo/PROJ/blob/master/src/datums.cpp
 @helmert Hermannskogel WGS84 (δx=577.326, δy=90.129, δz=463.919, θx=-5.137, θy=-1.474, θz=-5.297, s=2.4232)
 
@@ -89,9 +92,6 @@ include("transforms/sequential.jl")
 
 # https://epsg.org/transformation_10607/WGS-84-G2139-to-WGS-84-G2296-1.html
 @helmert WGS84{2139} WGS84{2296} (δx=2.6e-3, δy=5.4e-3, δz=-0.9e-3, θx=-0.01e-3, θy=-0.07e-3, s=0.06e-3)
-
-# https://epsg.org/transformation_1152/Hu-Tzu-Shan-1950-to-WGS-84-1.html
-@helmert HuTzuShan1950 WGS84 (δx=-637, δy=-549, δz=-203)
 
 # https://epsg.org/transformation_15929/BD72-to-WGS-84-3.html
 @helmert BD72 WGS84 (δx=-106.8686, δy=52.2978, δz=-103.7239, θx=-0.3366, θy=0.457, θz=-1.8422, s=-1.2747)

--- a/test/get.jl
+++ b/test/get.jl
@@ -40,6 +40,7 @@
   gettest(LatLon{Aratu}, EPSG{4208})
   gettest(LatLon{ED50}, EPSG{4230})
   gettest(LatLon{ED87}, EPSG{4231})
+  gettest(LatLon{HuTzuShan1950}, EPSG{4236})
   gettest(LatLon{NAD27}, EPSG{4267})
   gettest(LatLon{NAD83}, EPSG{4269})
   gettest(LatLon{Datum73}, EPSG{4274})


### PR DESCRIPTION
Adds support for reading the EPSG:4236 CRS. Also contains a transformation. Also contains a transformation.

All numbers taken from projinfo:
```
$ projinfo EPSG:4236
PROJ.4 string:
+proj=longlat +ellps=intl +towgs84=-637,-549,-203,0,0,0,0 +no_defs +type=crs

WKT2:2019 string:
GEOGCRS["Hu Tzu Shan 1950",
    DATUM["Hu Tzu Shan 1950",
        ELLIPSOID["International 1924",6378388,297,
            LENGTHUNIT["metre",1]]],
    PRIMEM["Greenwich",0,
        ANGLEUNIT["degree",0.0174532925199433]],
    CS[ellipsoidal,2],
        AXIS["geodetic latitude (Lat)",north,
            ORDER[1],
            ANGLEUNIT["degree",0.0174532925199433]],
        AXIS["geodetic longitude (Lon)",east,
            ORDER[2],
            ANGLEUNIT["degree",0.0174532925199433]],
    USAGE[
        SCOPE["Geodesy."],
        AREA["Taiwan, Republic of China - onshore - Taiwan Island, Penghu (Pescadores) Islands."],
        BBOX[21.87,119.25,25.34,122.06]],
    ID["EPSG",4236]]
```