### PR TITLE
Fix Orthographic round-trip at the limb

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -160,12 +160,12 @@ function projinv(fx, fy, x, y, λₒ, ϕₒ; maxiter=10, tol=atol(x))
   ∇f₂(λ, ϕ) = gradient(u -> f₂(u[1], u[2]), SVector(λ, ϕ))
 
   # norm of the deviation
-  dev(λ, ϕ) = hypot(f₁(λ, ϕ), f₂(λ, ϕ))
+  ε(λ, ϕ) = hypot(f₁(λ, ϕ), f₂(λ, ϕ))
 
   # Newton-Rhapson iteration
   λᵢ = λₒ
   ϕᵢ = ϕₒ
-  devᵢ = dev(λᵢ, ϕᵢ)
+  εᵢ = ε(λᵢ, ϕᵢ)
   for _ in 1:maxiter
     v₁ = f₁(λᵢ, ϕᵢ)
     v₂ = f₂(λᵢ, ϕᵢ)
@@ -176,17 +176,18 @@ function projinv(fx, fy, x, y, λₒ, ϕₒ; maxiter=10, tol=atol(x))
     den = (df₁dϕ * df₂dλ - df₂dϕ * df₁dλ)
     λᵢ₊₁ = λᵢ - (v₂ * df₁dϕ - v₁ * df₂dϕ) / den
     ϕᵢ₊₁ = ϕᵢ - (v₁ * df₂dλ - v₂ * df₁dλ) / den
+    εᵢ₊₁ = ε(λᵢ₊₁, ϕᵢ₊₁)
 
     # reject steps that do not reduce the deviation, which happens
     # where the Jacobian is singular, e.g. at the limb of the projection
-    devᵢ₊₁ = dev(λᵢ₊₁, ϕᵢ₊₁)
-    (isfinite(devᵢ₊₁) && devᵢ₊₁ < devᵢ) || break
+    (isfinite(εᵢ₊₁) && εᵢ₊₁ < εᵢ) || break
 
+    # assess convergence in latitude and longitude values
     converged = abs(λᵢ₊₁ - λᵢ) ≤ tol && abs(ϕᵢ₊₁ - ϕᵢ) ≤ tol
 
     λᵢ = λᵢ₊₁
     ϕᵢ = ϕᵢ₊₁
-    devᵢ = devᵢ₊₁
+    εᵢ = εᵢ₊₁
 
     converged && break
   end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -159,9 +159,13 @@ function projinv(fx, fy, x, y, λₒ, ϕₒ; maxiter=10, tol=atol(x))
   ∇f₁(λ, ϕ) = gradient(u -> f₁(u[1], u[2]), SVector(λ, ϕ))
   ∇f₂(λ, ϕ) = gradient(u -> f₂(u[1], u[2]), SVector(λ, ϕ))
 
+  # norm of the deviation
+  dev(λ, ϕ) = hypot(f₁(λ, ϕ), f₂(λ, ϕ))
+
   # Newton-Rhapson iteration
-  λᵢ₊₁ = λᵢ = λₒ
-  ϕᵢ₊₁ = ϕᵢ = ϕₒ
+  λᵢ = λₒ
+  ϕᵢ = ϕₒ
+  devᵢ = dev(λᵢ, ϕᵢ)
   for _ in 1:maxiter
     v₁ = f₁(λᵢ, ϕᵢ)
     v₂ = f₂(λᵢ, ϕᵢ)
@@ -173,15 +177,21 @@ function projinv(fx, fy, x, y, λₒ, ϕₒ; maxiter=10, tol=atol(x))
     λᵢ₊₁ = λᵢ - (v₂ * df₁dϕ - v₁ * df₂dϕ) / den
     ϕᵢ₊₁ = ϕᵢ - (v₁ * df₂dλ - v₂ * df₁dλ) / den
 
-    if abs(λᵢ₊₁ - λᵢ) ≤ tol && abs(ϕᵢ₊₁ - ϕᵢ) ≤ tol
-      break
-    end
+    # reject steps that do not reduce the deviation, which happens
+    # where the Jacobian is singular, e.g. at the limb of the projection
+    devᵢ₊₁ = dev(λᵢ₊₁, ϕᵢ₊₁)
+    (isfinite(devᵢ₊₁) && devᵢ₊₁ < devᵢ) || break
+
+    converged = abs(λᵢ₊₁ - λᵢ) ≤ tol && abs(ϕᵢ₊₁ - ϕᵢ) ≤ tol
 
     λᵢ = λᵢ₊₁
     ϕᵢ = ϕᵢ₊₁
+    devᵢ = devᵢ₊₁
+
+    converged && break
   end
 
-  λᵢ₊₁, ϕᵢ₊₁
+  λᵢ, ϕᵢ
 end
 
 """

--- a/test/crs/fwdbwd.jl
+++ b/test/crs/fwdbwd.jl
@@ -17,10 +17,6 @@
     # https://github.com/JuliaEarth/CoordRefSystems.jl/issues/268
     PRJ <: LambertAzimuthal && continue
 
-    # https://github.com/JuliaEarth/CoordRefSystems.jl/issues/272
-    PRJ <: OrthoNorth && continue
-    PRJ <: OrthoSouth && continue
-
     # https://github.com/JuliaEarth/CoordRefSystems.jl/issues/295
     PRJ <: Sinusoidal && continue
 
@@ -46,6 +42,16 @@
       # the LambertConic projection maps all values of the form (90, lon) to (xₒ, y)
       # therefore we cannot recover the original lon value when lat=90
       PRJ <: LambertConic && lat == T(90) && continue
+
+      # the Orthographic projection maps all values of the form (90, lon) to (xₒ, yₒ)
+      # therefore we cannot recover the original lon value at the pole
+      PRJ <: OrthoNorth && lat == T(90) && continue
+      PRJ <: OrthoSouth && lat == T(-90) && continue
+
+      # at the limb of the Orthographic projection the derivative of the radius
+      # with respect to the latitude vanishes, so only half of the significant
+      # digits of the latitude can be recovered
+      PRJ <: Union{OrthoNorth,OrthoSouth} && lat == T(0) && continue
 
       ll = LatLon(lat, lon)
       LL = typeof(ll)


### PR DESCRIPTION
Closes #272.

At the limb the Jacobian determinant collapses to ~1e-17 and `projinv` stepped away from a seed that was already exact, landing on a negative latitude. It now rejects steps that do not reduce the deviation.

Dropped the blanket skip in fwdbwd.jl. Two narrow ones remain, both inherent: longitude is undefined at the pole, same as LambertConic, and at the limb only half the digits of the latitude survive, the error is sqrt(eps).

WinkelTripel is the only other user of `projinv`, its round-trip is unchanged.
