### PR TITLE
Fix Sinusoidal round-trip at the poles

### DIFF
--- a/src/crs/projected/sinusoidal.jl
+++ b/src/crs/projected/sinusoidal.jl
@@ -67,7 +67,8 @@ end
 
 function backward(::Type{<:Sinusoidal}, x, y)
   ϕ = y
-  λ = x / cos(ϕ)
+  cosϕ = cos(ϕ)
+  λ = abs(cosϕ) < atol(x) ? zero(x) : x / cosϕ
 
   λ, ϕ
 end

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -1709,6 +1709,17 @@
       c3 = convert(LatLon, c2)
       @test isapprox(c3, c1)
 
+      # the poles collapse to a single point and the longitude is undefined
+      c1 = LatLon(T(90), T(45))
+      c2 = convert(Sinusoidal, c1)
+      c3 = convert(LatLon, c2)
+      @test isapprox(c3, LatLon(T(90), T(0)))
+
+      c1 = LatLon(-T(90), T(45))
+      c2 = convert(Sinusoidal, c1)
+      c3 = convert(LatLon, c2)
+      @test isapprox(c3, LatLon(-T(90), T(0)))
+
       # type stability
       c1 = LatLon(T(45), T(90))
       c2 = Sinusoidal(T(7.084329013634147e6), T(5.009377085697311e6))

--- a/test/crs/fwdbwd.jl
+++ b/test/crs/fwdbwd.jl
@@ -17,9 +17,6 @@
     # https://github.com/JuliaEarth/CoordRefSystems.jl/issues/268
     PRJ <: LambertAzimuthal && continue
 
-    # https://github.com/JuliaEarth/CoordRefSystems.jl/issues/295
-    PRJ <: Sinusoidal && continue
-
     # https://github.com/JuliaEarth/CoordRefSystems.jl/issues/296
     PRJ <: Albers && continue
 
@@ -52,6 +49,10 @@
       # with respect to the latitude vanishes, so only half of the significant
       # digits of the latitude can be recovered
       PRJ <: Union{OrthoNorth,OrthoSouth} && lat == T(0) && continue
+
+      # the Sinusoidal projection maps all values of the form (±90, lon) to (0, y)
+      # therefore we cannot recover the original lon value at the poles
+      PRJ <: Sinusoidal && abs(lat) == T(90) && continue
 
       ll = LatLon(lat, lon)
       LL = typeof(ll)


### PR DESCRIPTION
Closes #295.

The projection collapses each pole to a single point, so `x / cos(ϕ)` is 0/0 there. `cos` is hypersensitive near ±π/2, a 2e-16 shift in ϕ flips its sign, so the round trip returned lon=-17° for an input of 45°. It now returns zero at the poles, matching the guards already in Orthographic and LambertAzimuthal.

Dropped the blanket skip in fwdbwd.jl and kept a narrow one at lat=±90 where longitude is undefined, same as LambertConic. Everything else passes in both Float32 and Float64. Sinusoidal now shows up in the existing lon=180 sign flip warning.
