### PR TITLE
Fix LambertAzimuthal accuracy near the antipode

### DIFF
--- a/src/crs/projected/lambertazm.jl
+++ b/src/crs/projected/lambertazm.jl
@@ -67,12 +67,11 @@ function inbounds(::Type{<:LambertAzimuthal{latₒ,Datum}}, λ, ϕ) where {lat�
   q = authq(ϕ, e, ome²)
   βₒ = geod2auth(qₒ, qₚ)
   β = geod2auth(q, qₚ)
-  sinβₒ, cosβₒ = sincos(βₒ)
-  sinβ, cosβ = sincos(β)
-  cosλ = cos(λ)
+  cosβₒ = cos(βₒ)
+  cosβ = cos(β)
 
   # check if the denominator of the B equation is not equal (or approx) to zero
-  Bden = 1 + (sinβₒ * sinβ) + (cosβₒ * cosβ * cosλ)
+  Bden = _laeaBden(βₒ, β, cosβₒ, cosβ, λ)
   abs(Bden) > atol(λ)
 end
 
@@ -91,14 +90,14 @@ function formulas(::Type{<:LambertAzimuthal{latₒ,Datum}}, ::Type{T}) where {la
 
   Rq = sqrt(qₚ / 2)
   D = (cosϕₒ / sqrt(1 - e² * sinϕₒ^2)) / (Rq * cosβₒ)
-  fB(cosλ, sinβ, cosβ) = Rq * sqrt(2 / (1 + (sinβₒ * sinβ) + (cosβₒ * cosβ * cosλ)))
+  fB(λ, β, cosβ) = Rq * sqrt(2 / _laeaBden(βₒ, β, cosβₒ, cosβ, λ))
 
   function fx(λ, ϕ)
     q = authq(ϕ, e, ome²)
     β = geod2auth(q, qₚ)
-    sinβ, cosβ = sincos(β)
-    sinλ, cosλ = sincos(λ)
-    B = fB(cosλ, sinβ, cosβ)
+    cosβ = cos(β)
+    sinλ = sin(λ)
+    B = fB(λ, β, cosβ)
     (B * D) * (cosβ * sinλ)
   end
 
@@ -107,7 +106,7 @@ function formulas(::Type{<:LambertAzimuthal{latₒ,Datum}}, ::Type{T}) where {la
     β = geod2auth(q, qₚ)
     sinβ, cosβ = sincos(β)
     cosλ = cos(λ)
-    B = fB(cosλ, sinβ, cosβ)
+    B = fB(λ, β, cosβ)
     (B / D) * ((cosβₒ * sinβ) - (sinβₒ * cosβ * cosλ))
   end
 
@@ -133,7 +132,7 @@ function forward(::Type{<:LambertAzimuthal{latₒ,Datum}}, λ, ϕ) where {latₒ
 
   Rq = sqrt(qₚ / 2)
   # check if the denominator of the B equation is not equal (or approx) to zero
-  Bden = (1 + (sinβₒ * sinβ) + (cosβₒ * cosβ * cosλ))
+  Bden = _laeaBden(βₒ, β, cosβₒ, cosβ, λ)
   if abs(Bden) < atol(λ)
     throw(ArgumentError("coordinates outside of the projection domain"))
   end
@@ -178,6 +177,14 @@ function backward(::Type{<:LambertAzimuthal{latₒ,Datum}}, x, y) where {latₒ,
     λ, ϕ
   end
 end
+
+# -----------------
+# HELPER FUNCTIONS
+# -----------------
+
+# 1 + cos(c) with c the angular distance to the center of the projection, written
+# as a sum of non-negative terms to avoid cancellation near the antipode
+_laeaBden(βₒ, β, cosβₒ, cosβ, λ) = 2 * (sin((β + βₒ) / 2)^2 + (cosβₒ * cosβ) * cos(λ / 2)^2)
 
 # ----------
 # FALLBACKS

--- a/test/crs/conversions.jl
+++ b/test/crs/conversions.jl
@@ -1771,6 +1771,21 @@
       c3 = convert(LatLon, c2)
       @test isapprox(c3, c1)
 
+      # https://github.com/JuliaEarth/CoordRefSystems.jl/issues/265
+      # at the pole the argument of the arcsine reaches one, so the latitude
+      # keeps only half of its significant digits
+      c1 = LatLon(-T(90), T(0))
+      c2 = convert(LAEA, c1)
+      c3 = convert(LatLon, c2)
+      @test abs(c3.lat - c1.lat) < 2 * sqrt(eps(T)) * T(90) * °
+
+      # https://github.com/JuliaEarth/CoordRefSystems.jl/issues/268
+      # one degree away from the antipode of the projection center
+      c1 = LatLon(-T(14), T(180))
+      c2 = convert(LAEA, c1)
+      c3 = convert(LatLon, c2)
+      @test abs(c3.lat - c1.lat) < T(0.001) * T(90) * °
+
       # invert central coordinates
       ShiftedLAEA = CoordRefSystems.shift(LambertAzimuthal{30.0°,WGS84Latest}, lonₒ=60°)
       c1 = LatLon(T(30), T(60))

--- a/test/crs/fwdbwd.jl
+++ b/test/crs/fwdbwd.jl
@@ -13,10 +13,6 @@
     # https://github.com/JuliaEarth/CoordRefSystems.jl/issues/55
     PRJ <: Robinson && continue
 
-    # https://github.com/JuliaEarth/CoordRefSystems.jl/issues/265
-    # https://github.com/JuliaEarth/CoordRefSystems.jl/issues/268
-    PRJ <: LambertAzimuthal && continue
-
     # loop over all possible latitude and longitude values
     # that should be recovered by the given PRJ type
     success = true
@@ -52,6 +48,17 @@
       # the Albers projection compresses the latitude near the poles,
       # so only half of the significant digits of the latitude can be recovered
       PRJ <: Albers && abs(lat) == T(90) && continue
+
+      # at the poles the argument of the arcsine in the LambertAzimuthal inverse
+      # approaches one, so only half of the significant digits of the latitude
+      # can be recovered
+      PRJ <: LambertAzimuthal && abs(lat) == T(90) && continue
+
+      # the LambertAzimuthal projection above is centered at lat=15, so its antipode
+      # is the point (-15, 180). The derivative of the radius with respect to the
+      # angular distance vanishes there, and within one degree of it the latitude
+      # loses half of its significant digits in Float32
+      PRJ <: LambertAzimuthal && abs(lon) == T(180) && abs(lat + T(15)) ≤ T(1) && continue
 
       ll = LatLon(lat, lon)
       LL = typeof(ll)


### PR DESCRIPTION
Closes #265, closes #268.

`1 + sinβₒsinβ + cosβₒcosβcosλ` is 1 + cos of the angular distance, so it cancels badly near the antipode. Rewrote it as `2(sin²((β+βₒ)/2) + cosβcosβₒcos²(λ/2))`, same value but a sum of non-negative terms. It was inlined in three places so it now sits in a helper.

Float32 worst round-trip error drops from 1.0° to 0.0197° and the mean from 4.7e-4 to 1.0e-4. Float64 is unchanged and the PROJ reference tests are untouched.

Dropped the blanket skip in fwdbwd.jl and kept two narrow ones. At the poles the arcsine argument reaches one so the error is sqrt(eps), 1.4721739e-6° predicted against 1.4721737e-6° measured. Near the antipode the amplification is 2/cos(c/2), about 229 at one degree out, so Float32 still misses four points there.
