### PR TITLE
Test Albers round-trip away from the poles

### DIFF
--- a/test/crs/fwdbwd.jl
+++ b/test/crs/fwdbwd.jl
@@ -17,9 +17,6 @@
     # https://github.com/JuliaEarth/CoordRefSystems.jl/issues/268
     PRJ <: LambertAzimuthal && continue
 
-    # https://github.com/JuliaEarth/CoordRefSystems.jl/issues/296
-    PRJ <: Albers && continue
-
     # loop over all possible latitude and longitude values
     # that should be recovered by the given PRJ type
     success = true
@@ -51,6 +48,10 @@
       PRJ <: LambertCylindrical && abs(lat) == T(90) && continue
       PRJ <: Behrmann && abs(lat) == T(90) && continue
       PRJ <: GallPeters && abs(lat) == T(90) && continue
+
+      # the Albers projection compresses the latitude near the poles,
+      # so only half of the significant digits of the latitude can be recovered
+      PRJ <: Albers && abs(lat) == T(90) && continue
 
       ll = LatLon(lat, lon)
       LL = typeof(ll)


### PR DESCRIPTION
Related to #296.

Could not find a bug here. The implementation reproduces every intermediate of Snyder's ellipsoid worked example, m, q, n, C and ρ, with x and y within 5 mm, and no datum throws at the poles.

The pole error is arcsine conditioning. `asin(α/qₚ)` reaches an argument of one there so the latitude keeps only half its digits, 2.8189985e-6° predicted against 2.8189981e-6° measured at lat -90. α itself is accurate to 1e-16 so nothing upstream is losing precision.

So this only drops the blanket skip in fwdbwd.jl and keeps a narrow one at lat ±90. Albers gets round-trip coverage everywhere else in both float types. Leaving it to you whether that closes #296.
