### PR TITLE
Map polar stereographic EPSG codes to Stereographic

### DIFF
--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -23,6 +23,7 @@ include("crs.jl")
 include("transforms.jl")
 include("promotion.jl")
 include("utm.jl")
+include("stereo.jl")
 include("shift.jl")
 include("codes.jl")
 include("strings.jl")
@@ -139,6 +140,11 @@ export
   utm,
   utmnorth,
   utmsouth,
+
+  # Polar Stereographic
+  stereo,
+  stereonorth,
+  stereosouth,
 
   # codes
   EPSG,

--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -22,8 +22,8 @@ include("modes.jl")
 include("crs.jl")
 include("transforms.jl")
 include("promotion.jl")
-include("utm.jl")
 include("stereo.jl")
+include("utm.jl")
 include("shift.jl")
 include("codes.jl")
 include("strings.jl")
@@ -136,15 +136,15 @@ export
   isequidistant,
   iscompromise,
 
-  # UTM
-  utm,
-  utmnorth,
-  utmsouth,
-
-  # Polar Stereographic
+  # polar stereographic
   stereo,
   stereonorth,
   stereosouth,
+
+  # universal transverse mercator
+  utm,
+  utmnorth,
+  utmsouth,
 
   # codes
   EPSG,

--- a/src/get.jl
+++ b/src/get.jl
@@ -77,6 +77,14 @@ end
 @crscodes shift(TransverseMercator{0.9993,0.0°,ETRF{2000}}, lonₒ=19.0°, xₒ=500000.0m, yₒ=-5300000.0m) EPSG{2180}
 @crscodes shift(TransverseMercator{0.9996,0.0°,NZGD2000}, lonₒ=173.0°, xₒ=1600000.0m, yₒ=10000000.0m) EPSG{2193}
 @crscodes shift(Albers{45.0°,50.0°,58.5°,NAD83}, lonₒ=-126.0°, yₒ=1000000.0m) EPSG{3005}
+# The polar stereographic CRSs below are defined with a latitude of true scale
+# ϕc rather than a scale factor. The equivalent k₀ follows equation 21-35 of
+# Snyder, evaluated at ϕc with the eccentricity e of the ellipsoid:
+#
+#   mc = cos(ϕc) / sqrt(1 - e² sin²(ϕc))
+#   tc = tan(π/4 - ϕc/2) / ((1 - e sin(ϕc)) / (1 + e sin(ϕc)))^(e/2)
+#   k₀ = mc * sqrt((1 + e)^(1 + e) * (1 - e)^(1 - e)) / 2tc
+#
 # k₀ equivalent to the latitude of true scale -71°
 @crscodes Stereographic{EllipticalMode,0.9727690128917972,-90°,WGS84Latest} EPSG{3031}
 @crscodes shift(LambertAzimuthal{52.0°,ETRFLatest}, lonₒ=10.0°, xₒ=4321000.0m, yₒ=3210000.0m) EPSG{3035}

--- a/src/get.jl
+++ b/src/get.jl
@@ -77,13 +77,19 @@ end
 @crscodes shift(TransverseMercator{0.9993,0.0°,ETRF{2000}}, lonₒ=19.0°, xₒ=500000.0m, yₒ=-5300000.0m) EPSG{2180}
 @crscodes shift(TransverseMercator{0.9996,0.0°,NZGD2000}, lonₒ=173.0°, xₒ=1600000.0m, yₒ=10000000.0m) EPSG{2193}
 @crscodes shift(Albers{45.0°,50.0°,58.5°,NAD83}, lonₒ=-126.0°, yₒ=1000000.0m) EPSG{3005}
+# k₀ equivalent to the latitude of true scale -71°
+@crscodes Stereographic{EllipticalMode,0.9727690128917972,-90°,WGS84Latest} EPSG{3031}
 @crscodes shift(LambertAzimuthal{52.0°,ETRFLatest}, lonₒ=10.0°, xₒ=4321000.0m, yₒ=3210000.0m) EPSG{3035}
 @crscodes shift(LambertConic{65.0°,64.25°,65.75°,ISN93}, lonₒ=-19.0°, xₒ=500000.0m, yₒ=500000.0m) EPSG{3057}
 @crscodes shift(Albers{0.0°,34.0°,40.5°,NAD83}, lonₒ=-120.0°, yₒ=-4000000.0m) EPSG{3310}
 @crscodes shift(Albers{50.0°,55.0°,65.0°,NAD83}, lonₒ=-154.0°) EPSG{3338}
 @crscodes Mercator{WGS84Latest} EPSG{3395}
+# k₀ equivalent to the latitude of true scale 70°
+@crscodes shift(Stereographic{EllipticalMode,0.969858190326352,90°,WGS84Latest}, lonₒ=-45.0°) EPSG{3413}
 @crscodes shift(Albers{0.0°,-18.0°,-36.0°,GDA94}, lonₒ=132.0°) EPSG{3577}
 @crscodes WebMercator{WGS84Latest} EPSG{3857}
+# k₀ equivalent to the latitude of true scale 71°
+@crscodes Stereographic{EllipticalMode,0.9727690128917972,90°,WGS84Latest} EPSG{3995}
 @crscodes LatLon{RGF93v1} EPSG{4171}
 @crscodes LatLon{Lisbon1937} EPSG{4207}
 @crscodes LatLon{Aratu} EPSG{4208}

--- a/src/get.jl
+++ b/src/get.jl
@@ -77,27 +77,16 @@ end
 @crscodes shift(TransverseMercator{0.9993,0.0°,ETRF{2000}}, lonₒ=19.0°, xₒ=500000.0m, yₒ=-5300000.0m) EPSG{2180}
 @crscodes shift(TransverseMercator{0.9996,0.0°,NZGD2000}, lonₒ=173.0°, xₒ=1600000.0m, yₒ=10000000.0m) EPSG{2193}
 @crscodes shift(Albers{45.0°,50.0°,58.5°,NAD83}, lonₒ=-126.0°, yₒ=1000000.0m) EPSG{3005}
-# The polar stereographic CRSs below are defined with a latitude of true scale
-# ϕc rather than a scale factor. The equivalent k₀ follows equation 21-35 of
-# Snyder, evaluated at ϕc with the eccentricity e of the ellipsoid:
-#
-#   mc = cos(ϕc) / sqrt(1 - e² sin²(ϕc))
-#   tc = tan(π/4 - ϕc/2) / ((1 - e sin(ϕc)) / (1 + e sin(ϕc)))^(e/2)
-#   k₀ = mc * sqrt((1 + e)^(1 + e) * (1 - e)^(1 - e)) / 2tc
-#
-# k₀ equivalent to the latitude of true scale -71°
-@crscodes Stereographic{EllipticalMode,0.9727690128917972,-90°,WGS84Latest} EPSG{3031}
+@crscodes stereosouth(71.0°) EPSG{3031}
 @crscodes shift(LambertAzimuthal{52.0°,ETRFLatest}, lonₒ=10.0°, xₒ=4321000.0m, yₒ=3210000.0m) EPSG{3035}
 @crscodes shift(LambertConic{65.0°,64.25°,65.75°,ISN93}, lonₒ=-19.0°, xₒ=500000.0m, yₒ=500000.0m) EPSG{3057}
 @crscodes shift(Albers{0.0°,34.0°,40.5°,NAD83}, lonₒ=-120.0°, yₒ=-4000000.0m) EPSG{3310}
 @crscodes shift(Albers{50.0°,55.0°,65.0°,NAD83}, lonₒ=-154.0°) EPSG{3338}
 @crscodes Mercator{WGS84Latest} EPSG{3395}
-# k₀ equivalent to the latitude of true scale 70°
-@crscodes shift(Stereographic{EllipticalMode,0.969858190326352,90°,WGS84Latest}, lonₒ=-45.0°) EPSG{3413}
+@crscodes stereonorth(70.0°, lonₒ=-45.0°) EPSG{3413}
 @crscodes shift(Albers{0.0°,-18.0°,-36.0°,GDA94}, lonₒ=132.0°) EPSG{3577}
 @crscodes WebMercator{WGS84Latest} EPSG{3857}
-# k₀ equivalent to the latitude of true scale 71°
-@crscodes Stereographic{EllipticalMode,0.9727690128917972,90°,WGS84Latest} EPSG{3995}
+@crscodes stereonorth(71.0°) EPSG{3995}
 @crscodes LatLon{RGF93v1} EPSG{4171}
 @crscodes LatLon{Lisbon1937} EPSG{4207}
 @crscodes LatLon{Aratu} EPSG{4208}

--- a/src/stereo.jl
+++ b/src/stereo.jl
@@ -50,9 +50,9 @@ stereosouth(latₜₛ; kwargs...) = stereo(:south, latₜₛ; kwargs...)
 # scale factor at the pole for a given latitude of true scale,
 # equation 21-35 of Snyder, with true scale at the pole itself
 # corresponding to a unit scale factor
-function scalefactor(ϕₜₛ, E)
+function scalefactor(ϕₜₛ, 🌎)
   ϕₜₛ == 90° && return 1.0
-  e = eccentricity(E)
+  e = eccentricity(🌎)
   esinϕ = e * sin(ϕₜₛ)
   m = cos(ϕₜₛ) / sqrt(1 - esinϕ^2)
   t = tan(45° - ϕₜₛ / 2) / ((1 - esinϕ) / (1 + esinϕ))^(e / 2)

--- a/src/stereo.jl
+++ b/src/stereo.jl
@@ -1,0 +1,60 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+"""
+    stereo(hemisphere, latₜₛ; lonₒ=0.0°, datum=WGS84Latest)
+
+Polar Stereographic CRS in `hemisphere` (`:north` or `:south`) with latitude of
+true scale `latₜₛ`, central meridian `lonₒ` and a given `datum`.
+
+EPSG defines polar stereographic CRSs with a latitude of true scale, while the
+[`Stereographic`](@ref) type is parametrized by the scale factor `k₀` that also
+covers the oblique aspect. This function converts between the two.
+
+Only the magnitude of `latₜₛ` is used, the `hemisphere` selects the pole.
+
+See also [`stereonorth`](@ref), [`stereosouth`](@ref).
+"""
+function stereo(hemisphere, latₜₛ; lonₒ=0.0°, datum=WGS84Latest)
+  if hemisphere ∉ (:north, :south)
+    throw(ArgumentError("invalid hemisphere, please use `:north` or `:south`"))
+  end
+
+  ϕₜₛ = abs(asdeg(latₜₛ))
+
+  if !(0° < ϕₜₛ ≤ 90°)
+    throw(ArgumentError("the latitude of true scale must be greater than 0° and at most 90°"))
+  end
+
+  k₀ = scalefactor(ϕₜₛ, ellipsoid(datum))
+  latₒ = hemisphere == :north ? 90.0° : -90.0°
+  S = Shift(; lonₒ)
+  Stereographic{EllipticalMode,k₀,latₒ,datum,S}
+end
+
+"""
+    stereonorth(latₜₛ; lonₒ=0.0°, datum=WGS84Latest)
+
+North Polar Stereographic CRS with latitude of true scale `latₜₛ`.
+"""
+stereonorth(latₜₛ; kwargs...) = stereo(:north, latₜₛ; kwargs...)
+
+"""
+    stereosouth(latₜₛ; lonₒ=0.0°, datum=WGS84Latest)
+
+South Polar Stereographic CRS with latitude of true scale `latₜₛ`.
+"""
+stereosouth(latₜₛ; kwargs...) = stereo(:south, latₜₛ; kwargs...)
+
+# scale factor at the pole for a given latitude of true scale,
+# equation 21-35 of Snyder, with true scale at the pole itself
+# corresponding to a unit scale factor
+function scalefactor(ϕₜₛ, E)
+  ϕₜₛ == 90° && return 1.0
+  e = eccentricity(E)
+  esinϕ = e * sin(ϕₜₛ)
+  m = cos(ϕₜₛ) / sqrt(1 - esinϕ^2)
+  t = tan(45° - ϕₜₛ / 2) / ((1 - esinϕ) / (1 + esinϕ))^(e / 2)
+  m * sqrt((1 + e)^(1 + e) * (1 - e)^(1 - e)) / 2t
+end

--- a/test/get.jl
+++ b/test/get.jl
@@ -22,6 +22,7 @@
     EPSG{2193}
   )
   gettest(CoordRefSystems.shift(Albers{45.0°,50.0°,58.5°,NAD83}, lonₒ=-126.0°, yₒ=1000000.0m), EPSG{3005})
+  gettest(Stereographic{CoordRefSystems.EllipticalMode,0.9727690128917972,-90°,WGS84Latest}, EPSG{3031})
   gettest(
     CoordRefSystems.shift(LambertAzimuthal{52.0°,ETRFLatest}, lonₒ=10.0°, xₒ=4321000.0m, yₒ=3210000.0m),
     EPSG{3035}
@@ -33,8 +34,13 @@
   gettest(CoordRefSystems.shift(Albers{0.0°,34.0°,40.5°,NAD83}, lonₒ=-120.0°, yₒ=-4000000.0m), EPSG{3310})
   gettest(CoordRefSystems.shift(Albers{50.0°,55.0°,65.0°,NAD83}, lonₒ=-154.0°), EPSG{3338})
   gettest(Mercator{WGS84Latest}, EPSG{3395})
+  gettest(
+    CoordRefSystems.shift(Stereographic{CoordRefSystems.EllipticalMode,0.969858190326352,90°,WGS84Latest}, lonₒ=-45.0°),
+    EPSG{3413}
+  )
   gettest(CoordRefSystems.shift(Albers{0.0°,-18.0°,-36.0°,GDA94}, lonₒ=132.0°), EPSG{3577})
   gettest(WebMercator{WGS84Latest}, EPSG{3857})
+  gettest(Stereographic{CoordRefSystems.EllipticalMode,0.9727690128917972,90°,WGS84Latest}, EPSG{3995})
   gettest(LatLon{RGF93v1}, EPSG{4171})
   gettest(LatLon{Lisbon1937}, EPSG{4207})
   gettest(LatLon{Aratu}, EPSG{4208})

--- a/test/get.jl
+++ b/test/get.jl
@@ -22,7 +22,7 @@
     EPSG{2193}
   )
   gettest(CoordRefSystems.shift(Albers{45.0°,50.0°,58.5°,NAD83}, lonₒ=-126.0°, yₒ=1000000.0m), EPSG{3005})
-  gettest(Stereographic{CoordRefSystems.EllipticalMode,0.9727690128917972,-90°,WGS84Latest}, EPSG{3031})
+  gettest(stereosouth(71.0°), EPSG{3031})
   gettest(
     CoordRefSystems.shift(LambertAzimuthal{52.0°,ETRFLatest}, lonₒ=10.0°, xₒ=4321000.0m, yₒ=3210000.0m),
     EPSG{3035}
@@ -34,13 +34,10 @@
   gettest(CoordRefSystems.shift(Albers{0.0°,34.0°,40.5°,NAD83}, lonₒ=-120.0°, yₒ=-4000000.0m), EPSG{3310})
   gettest(CoordRefSystems.shift(Albers{50.0°,55.0°,65.0°,NAD83}, lonₒ=-154.0°), EPSG{3338})
   gettest(Mercator{WGS84Latest}, EPSG{3395})
-  gettest(
-    CoordRefSystems.shift(Stereographic{CoordRefSystems.EllipticalMode,0.969858190326352,90°,WGS84Latest}, lonₒ=-45.0°),
-    EPSG{3413}
-  )
+  gettest(stereonorth(70.0°, lonₒ=-45.0°), EPSG{3413})
   gettest(CoordRefSystems.shift(Albers{0.0°,-18.0°,-36.0°,GDA94}, lonₒ=132.0°), EPSG{3577})
   gettest(WebMercator{WGS84Latest}, EPSG{3857})
-  gettest(Stereographic{CoordRefSystems.EllipticalMode,0.9727690128917972,90°,WGS84Latest}, EPSG{3995})
+  gettest(stereonorth(71.0°), EPSG{3995})
   gettest(LatLon{RGF93v1}, EPSG{4171})
   gettest(LatLon{Lisbon1937}, EPSG{4207})
   gettest(LatLon{Aratu}, EPSG{4208})
@@ -139,6 +136,25 @@
   gettest(utmnorth(23, datum=SIRGAS2000), EPSG{6210})
   gettest(utmnorth(24, datum=SIRGAS2000), EPSG{6211})
   gettest(utmsouth(26, datum=SIRGAS2000), EPSG{5396})
+
+  # polar stereographic helpers
+  # the hemisphere sets the pole, only the magnitude of the latitude is used
+  @test stereonorth(71.0°) === stereo(:north, 71.0°)
+  @test stereosouth(71.0°) === stereo(:south, -71.0°)
+  @test stereonorth(71.0°) !== stereosouth(71.0°)
+  # true scale at the pole is a unit scale factor
+  @test CoordRefSystems.scalefactor(90.0°, CoordRefSystems.ellipsoid(WGS84Latest)) == 1
+  # scale factor decreases as the latitude of true scale moves away from the pole
+  let E = CoordRefSystems.ellipsoid(WGS84Latest)
+    ks = [CoordRefSystems.scalefactor(ϕ * °, E) for ϕ in (30, 50, 71, 85)]
+    @test issorted(ks)
+    @test all(0 .< ks .< 1)
+  end
+  # error: the hemisphere must be :north or :south
+  @test_throws ArgumentError stereo(:east, 71.0°)
+  # error: the latitude of true scale must be greater than 0° and at most 90°
+  @test_throws ArgumentError stereonorth(0.0°)
+  @test_throws ArgumentError stereonorth(91.0°)
 
   # CRS string
   str = wktstring(EPSG{3395})

--- a/test/get.jl
+++ b/test/get.jl
@@ -116,6 +116,25 @@
   gettest(CoordRefSystems.Orthographic{CoordRefSystems.SphericalMode,90°,WGS84Latest}, ESRI{102035})
   gettest(CoordRefSystems.Orthographic{CoordRefSystems.SphericalMode,-90°,WGS84Latest}, ESRI{102037})
 
+  # polar stereographic helpers
+  # the hemisphere sets the pole, only the magnitude of the latitude is used
+  @test stereonorth(71.0°) === stereo(:north, 71.0°)
+  @test stereosouth(71.0°) === stereo(:south, -71.0°)
+  @test stereonorth(71.0°) !== stereosouth(71.0°)
+  # true scale at the pole is a unit scale factor
+  @test CoordRefSystems.scalefactor(90.0°, CoordRefSystems.ellipsoid(WGS84Latest)) == 1
+  # scale factor decreases as the latitude of true scale moves away from the pole
+  let E = CoordRefSystems.ellipsoid(WGS84Latest)
+    ks = [CoordRefSystems.scalefactor(ϕ * °, E) for ϕ in (30, 50, 71, 85)]
+    @test issorted(ks)
+    @test all(0 .< ks .< 1)
+  end
+  # error: the hemisphere must be :north or :south
+  @test_throws ArgumentError stereo(:east, 71.0°)
+  # error: the latitude of true scale must be greater than 0° and at most 90°
+  @test_throws ArgumentError stereonorth(0.0°)
+  @test_throws ArgumentError stereonorth(91.0°)
+
   for zone in 1:60
     NorthCode = 32600 + zone
     SouthCode = 32700 + zone
@@ -136,25 +155,6 @@
   gettest(utmnorth(23, datum=SIRGAS2000), EPSG{6210})
   gettest(utmnorth(24, datum=SIRGAS2000), EPSG{6211})
   gettest(utmsouth(26, datum=SIRGAS2000), EPSG{5396})
-
-  # polar stereographic helpers
-  # the hemisphere sets the pole, only the magnitude of the latitude is used
-  @test stereonorth(71.0°) === stereo(:north, 71.0°)
-  @test stereosouth(71.0°) === stereo(:south, -71.0°)
-  @test stereonorth(71.0°) !== stereosouth(71.0°)
-  # true scale at the pole is a unit scale factor
-  @test CoordRefSystems.scalefactor(90.0°, CoordRefSystems.ellipsoid(WGS84Latest)) == 1
-  # scale factor decreases as the latitude of true scale moves away from the pole
-  let E = CoordRefSystems.ellipsoid(WGS84Latest)
-    ks = [CoordRefSystems.scalefactor(ϕ * °, E) for ϕ in (30, 50, 71, 85)]
-    @test issorted(ks)
-    @test all(0 .< ks .< 1)
-  end
-  # error: the hemisphere must be :north or :south
-  @test_throws ArgumentError stereo(:east, 71.0°)
-  # error: the latitude of true scale must be greater than 0° and at most 90°
-  @test_throws ArgumentError stereonorth(0.0°)
-  @test_throws ArgumentError stereonorth(91.0°)
 
   # CRS string
   str = wktstring(EPSG{3395})


### PR DESCRIPTION
Closes #239.

Adds EPSG:3031, 3995 and 3413. These are defined with a latitude of true scale, so the entries use the equivalent k₀.

Checked against PROJ, worst deviation 3.5e-10 m. Only 3031 is needed here, happy to drop the other two.
