### PR TITLE
Add EPSG code for Amersfoort / RD New

### DIFF
--- a/src/CoordRefSystems.jl
+++ b/src/CoordRefSystems.jl
@@ -50,6 +50,7 @@ export
   ETRFLatest,
   NAD83CSRS,
   NAD83CSRSLatest,
+  Amersfoort,
   Aratu,
   BD72,
   Carthage,

--- a/src/datums.jl
+++ b/src/datums.jl
@@ -181,6 +181,17 @@ epoch(::Type{NAD83CSRS{7}}) = 2010.0
 epoch(::Type{NAD83CSRS{8}}) = 2010.0
 
 """
+    Amersfoort
+
+Amersfoort datum.
+
+See <https://epsg.org/datum_6289/Amersfoort.html>
+"""
+abstract type Amersfoort <: Datum end
+
+ellipsoid(::Type{Amersfoort}) = Bessel🌎
+
+"""
     Aratu
 
 Aratu datum.

--- a/src/get.jl
+++ b/src/get.jl
@@ -131,6 +131,12 @@ end
 @crscodes shift(TransverseMercator{0.9996,0.0°,ETRFLatest}, lonₒ=9.0°, xₒ=500000.0m, yₒ=0.0m) EPSG{25832}
 @crscodes shift(TransverseMercator{0.9996012717,49.0°,OSGB36}, lonₒ=-2.0°, xₒ=400000.0m, yₒ=-100000.0m) EPSG{27700}
 @crscodes shift(TransverseMercator{0.9996,0.0°,GDA94}, lonₒ=147.0°, xₒ=500000.0m, yₒ=10000000.0m) EPSG{28355}
+@crscodes shift(
+  ObliqueStereographic{0.9999079,52.1561605555556°,Amersfoort},
+  lonₒ=5.38763888888889°,
+  xₒ=155000.0m,
+  yₒ=463000.0m
+) EPSG{28992}
 @crscodes shift(TransverseMercator{1.000035,53.5°,Ire65}, lonₒ=-8.0°, xₒ=200000.0m, yₒ=250000.0m) EPSG{29902} EPSG{
   29903
 }

--- a/test/get.jl
+++ b/test/get.jl
@@ -95,6 +95,15 @@
     EPSG{28355}
   )
   gettest(
+    CoordRefSystems.shift(
+      ObliqueStereographic{0.9999079,52.1561605555556°,Amersfoort},
+      lonₒ=5.38763888888889°,
+      xₒ=155000.0m,
+      yₒ=463000.0m
+    ),
+    EPSG{28992}
+  )
+  gettest(
     CoordRefSystems.shift(TransverseMercator{1.000035,53.5°,Ire65}, lonₒ=-8.0°, xₒ=200000.0m, yₒ=250000.0m),
     EPSG{29902},
     EPSG{29903}


### PR DESCRIPTION
Closes #315.

EPSG:28992 uses `sterea`, so it needed `ObliqueStereographic` from #370. Adds the Amersfoort datum on Bessel 1841 and maps the code.

Checked against PROJ at four points across the Netherlands, worst deviation 4.9e-7 m, which is the precision of the reference output. The RD origin lands on exactly 155000, 463000. Round-trip is 6.3e-9 m.

Not included: a Helmert transform from Amersfoort to WGS84. Without it `LatLon{Amersfoort}` works but conversions from WGS84 throw. Happy to add it here or separately if you want it.
